### PR TITLE
[RHI]Support pixel shader write and atomic operations.

### DIFF
--- a/Modules/Luna/RHI/CommandBuffer.hpp
+++ b/Modules/Luna/RHI/CommandBuffer.hpp
@@ -70,16 +70,18 @@ namespace Luna
 			uniform_buffer_ps = 0x20,
 			//! Used as a read-only resource for pixel shader.
 			shader_read_ps = 0x40,
+			//！Used as a write-only resource for pixel shader. Enabled only if pixel shader write feature is supported.
+			shader_write_ps = 0x80,
 			//! Used as a uniform buffer for compute shader.
-			uniform_buffer_cs = 0x80,
+			uniform_buffer_cs = 0x0100,
 			//! Used as a read-only resource for compute shader.
-			shader_read_cs = 0x0100,
+			shader_read_cs = 0x0200,
 			//! Used as a write-only resource for compute shader.
-			shader_write_cs = 0x0200,
+			shader_write_cs = 0x0400,
 			//! Used as a copy destination.
-			copy_dest = 0x0400,
+			copy_dest = 0x0800,
 			//! Used as a copy source.
-			copy_source = 0x0800,
+			copy_source = 0x1000,
 			//! If this is specified as the before state, the system determines the before state automatically using the last state 
 			//! specified in the same command buffer for the resource. If this is the first time the resource is used in the current
 			//! command buffer, the system loads the resource's global state automatically.
@@ -88,7 +90,8 @@ namespace Luna
 			//! state.
 			automatic = 0x80000000,
 
-			shader_read_write_cs = shader_read_cs | shader_write_cs
+			shader_read_write_ps = shader_read_ps | shader_write_ps,
+			shader_read_write_cs = shader_read_cs | shader_write_cs,
 		};
 		enum class TextureStateFlag : u32
 		{
@@ -97,29 +100,31 @@ namespace Luna
 			//! before it can be used.
 			none = 0x00,
 			//! Used as a sampled texture for vertex shader.
-			shader_read_vs = 0x10,
-			//! Used as a shader resource for pixel shader.
-			shader_read_ps = 0x20,
+			shader_read_vs = 0x01,
+			//! Used as a read-only resource for pixel shader.
+			shader_read_ps = 0x02,
+			//！Used as a write-only resource for pixel shader. Enabled only if pixel shader write feature is supported.
+			shader_write_ps = 0x04,
 			//! Used as a color attachment with read access.
-			color_attachment_read = 0x40,
+			color_attachment_read = 0x08,
 			//! Used as a color attachment with write access.
-			color_attachment_write = 0x80,
+			color_attachment_write = 0x10,
 			//! Used as a depth stencil attachment with read access.
-			depth_stencil_attachment_read = 0x0100,
+			depth_stencil_attachment_read = 0x20,
 			//! Used as a depth stencil attachment with write access.
-			depth_stencil_attachment_write = 0x0200,
+			depth_stencil_attachment_write = 0x40,
 			//! Used as a resolve attachment with write access.
-			resolve_attachment = 0x0400,
+			resolve_attachment = 0x80,
 			//! Used as a shader resource for compute shader.
-			shader_read_cs = 0x0800,
+			shader_read_cs = 0x0100,
 			//! Used as a read-only unordered access for compute shader.
-			shader_write_cs = 0x1000,
+			shader_write_cs = 0x0200,
 			//! Used as a copy destination.
-			copy_dest = 0x2000,
+			copy_dest = 0x0400,
 			//! Used as a copy source.
-			copy_source = 0x4000,
+			copy_source = 0x0800,
 			//! Used for swap chain presentation.
-			present = 0x8000,
+			present = 0x1000,
 			//! If this is specified as the before state, the system determines the before state automatically using the last state 
 			//! specified in the same command buffer for the resource. If this is the first time the resource is used in the current
 			//! command buffer, the system loads the resource's global state automatically.
@@ -127,7 +132,8 @@ namespace Luna
 			//! This state cannot be set as the after state of the resource. This state cannot be set along with other state flags.
 			automatic = 0x80000000,
 
-			shader_read_write_cs = shader_read_cs | shader_write_cs
+			shader_read_write_ps = shader_read_ps | shader_write_ps,
+			shader_read_write_cs = shader_read_cs | shader_write_cs,
 		};
 		constexpr SubresourceIndex TEXTURE_BARRIER_ALL_SUBRESOURCES = {U32_MAX, U32_MAX};
 		struct TextureBarrier

--- a/Modules/Luna/RHI/Device.hpp
+++ b/Modules/Luna/RHI/Device.hpp
@@ -28,6 +28,8 @@ namespace Luna
 		{
 			//! `DescriptorSetLayoutFlag::variable_descriptors` is allowed when creating descriptor set layout.
 			unbound_descriptor_array,
+			//! Allow pixel shaders to write and perform atomic operations on buffer and texture data.
+			pixel_shader_write,
 		};
 
 		enum class CommandQueueType : u8

--- a/Modules/Luna/RHI/Source/D3D12/D3D12Common.hpp
+++ b/Modules/Luna/RHI/Source/D3D12/D3D12Common.hpp
@@ -39,11 +39,14 @@ namespace Luna
 				test_flags(s, BufferStateFlag::uniform_buffer_vs) ||
 				test_flags(s, BufferStateFlag::uniform_buffer_ps))  r |= D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER;
 			if (test_flags(s, BufferStateFlag::index_buffer)) r |= D3D12_RESOURCE_STATE_INDEX_BUFFER;
-			if (test_flags(s, BufferStateFlag::shader_write_cs)) r |= D3D12_RESOURCE_STATE_UNORDERED_ACCESS;
-			if (test_flags(s, BufferStateFlag::shader_read_cs) &&
-				!test_flags(s, BufferStateFlag::shader_write_cs)) r |= D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE;
-			if (test_flags(s, BufferStateFlag::shader_read_vs)) r |= D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE;
-			if (test_flags(s, BufferStateFlag::shader_read_ps)) r |= D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
+			if (test_flags(s, BufferStateFlag::shader_write_ps) ||
+				test_flags(s, BufferStateFlag::shader_write_cs)) r |= D3D12_RESOURCE_STATE_UNORDERED_ACCESS;
+			if((r & D3D12_RESOURCE_STATE_UNORDERED_ACCESS) == 0)
+			{
+				if (test_flags(s, BufferStateFlag::shader_read_vs) ||
+					test_flags(s, BufferStateFlag::shader_read_cs)) r |= D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE;
+				if (test_flags(s, BufferStateFlag::shader_read_ps)) r |= D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
+			}
 			if (test_flags(s, BufferStateFlag::copy_dest)) r |= D3D12_RESOURCE_STATE_COPY_DEST;
 			if (test_flags(s, BufferStateFlag::copy_source)) r |= D3D12_RESOURCE_STATE_COPY_SOURCE;
 			return r;
@@ -51,17 +54,20 @@ namespace Luna
 		inline D3D12_RESOURCE_STATES encode_texture_state(TextureStateFlag s)
 		{
 			D3D12_RESOURCE_STATES r = D3D12_RESOURCE_STATE_COMMON;
-			if (test_flags(s, TextureStateFlag::shader_read_vs)) r |= D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE;
-			if (test_flags(s, TextureStateFlag::shader_read_ps)) r |= D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
 			if (test_flags(s, TextureStateFlag::color_attachment_read) ||
 				test_flags(s, TextureStateFlag::color_attachment_write)) r |= D3D12_RESOURCE_STATE_RENDER_TARGET;
 			if (test_flags(s, TextureStateFlag::depth_stencil_attachment_write)) r |= D3D12_RESOURCE_STATE_DEPTH_WRITE;
 			if (test_flags(s, TextureStateFlag::depth_stencil_attachment_read) &&
 				!test_flags(s, TextureStateFlag::depth_stencil_attachment_write)) r |= D3D12_RESOURCE_STATE_DEPTH_READ;
 			if (test_flags(s, TextureStateFlag::resolve_attachment)) r |= D3D12_RESOURCE_STATE_RESOLVE_DEST;
-			if (test_flags(s, TextureStateFlag::shader_write_cs)) r |= D3D12_RESOURCE_STATE_UNORDERED_ACCESS;
-			if (test_flags(s, TextureStateFlag::shader_read_cs) &&
-				!test_flags(s, TextureStateFlag::shader_write_cs)) r |= D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE;
+			if (test_flags(s, TextureStateFlag::shader_write_ps) ||
+				test_flags(s, TextureStateFlag::shader_write_cs)) r |= D3D12_RESOURCE_STATE_UNORDERED_ACCESS;
+			if((r & D3D12_RESOURCE_STATE_UNORDERED_ACCESS) == 0)
+			{
+				if (test_flags(s, TextureStateFlag::shader_read_vs) ||
+					test_flags(s, TextureStateFlag::shader_read_cs)) r |= D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE;
+				if (test_flags(s, TextureStateFlag::shader_read_ps)) r |= D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
+			}
 			if (test_flags(s, TextureStateFlag::copy_dest)) r |= D3D12_RESOURCE_STATE_COPY_DEST;
 			if (test_flags(s, TextureStateFlag::copy_source)) r |= D3D12_RESOURCE_STATE_COPY_SOURCE;
 			if (test_flags(s, TextureStateFlag::present)) r |= D3D12_RESOURCE_STATE_PRESENT;

--- a/Modules/Luna/RHI/Source/D3D12/Device.cpp
+++ b/Modules/Luna/RHI/Source/D3D12/Device.cpp
@@ -245,6 +245,7 @@ namespace Luna
 			switch (feature)
 			{
 			case DeviceFeature::unbound_descriptor_array: return true;
+			case DeviceFeature::pixel_shader_write: return true;
 			}
 			return false;
 		}

--- a/Modules/Luna/RHI/Source/Metal/Device.cpp
+++ b/Modules/Luna/RHI/Source/Metal/Device.cpp
@@ -119,6 +119,7 @@ namespace Luna
             switch (feature)
             {
             case DeviceFeature::unbound_descriptor_array: return m_support_metal_3_family;
+            case DeviceFeature::pixel_shader_write: return true;
             default: return false;
             }
         }

--- a/Modules/Luna/RHI/Source/Vulkan/Common.hpp
+++ b/Modules/Luna/RHI/Source/Vulkan/Common.hpp
@@ -356,7 +356,8 @@ namespace Luna
 			if (test_flags(state, BufferStateFlag::shader_read_vs) ||
 				test_flags(state, BufferStateFlag::shader_read_ps) ||
 				test_flags(state, BufferStateFlag::shader_read_cs)) f |= VK_ACCESS_SHADER_READ_BIT;
-			if (test_flags(state, BufferStateFlag::shader_write_cs)) f |= VK_ACCESS_SHADER_WRITE_BIT;
+			if (test_flags(state, BufferStateFlag::shader_write_ps) ||
+				test_flags(state, BufferStateFlag::shader_write_cs)) f |= VK_ACCESS_SHADER_WRITE_BIT;
 			if (test_flags(state, BufferStateFlag::copy_dest)) f |= VK_ACCESS_TRANSFER_WRITE_BIT;
 			if (test_flags(state, BufferStateFlag::copy_source)) f |= VK_ACCESS_TRANSFER_READ_BIT;
 			return f;
@@ -367,7 +368,8 @@ namespace Luna
 			if (test_flags(state, TextureStateFlag::shader_read_vs) ||
 				test_flags(state, TextureStateFlag::shader_read_ps) ||
 				test_flags(state, TextureStateFlag::shader_read_cs)) f |= VK_ACCESS_SHADER_READ_BIT;
-			if (test_flags(state, TextureStateFlag::shader_write_cs)) f |= VK_ACCESS_SHADER_WRITE_BIT;
+			if (test_flags(state, TextureStateFlag::shader_write_ps) ||
+				test_flags(state, TextureStateFlag::shader_write_cs)) f |= VK_ACCESS_SHADER_WRITE_BIT;
 			if (test_flags(state, TextureStateFlag::color_attachment_read)) f |= VK_ACCESS_COLOR_ATTACHMENT_READ_BIT;
 			if (test_flags(state, TextureStateFlag::color_attachment_write) ||
 				test_flags(state, TextureStateFlag::resolve_attachment)) f |= VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
@@ -405,7 +407,8 @@ namespace Luna
 			if ((test_flags(state, TextureStateFlag::shader_read_vs) ||
 				 test_flags(state, TextureStateFlag::shader_read_ps) ||
 				 test_flags(state, TextureStateFlag::shader_read_cs)) &&
-				(!test_flags(state, TextureStateFlag::shader_write_cs))
+				(!test_flags(state, TextureStateFlag::shader_write_ps) &&
+				 !test_flags(state, TextureStateFlag::shader_write_cs))
 				)
 			{
 				return VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
@@ -435,7 +438,8 @@ namespace Luna
 					flags |= VK_PIPELINE_STAGE_VERTEX_SHADER_BIT;
 				}
 				if (test_flags(state, BufferStateFlag::uniform_buffer_ps) ||
-					test_flags(state, BufferStateFlag::shader_read_ps))
+					test_flags(state, BufferStateFlag::shader_read_ps) ||
+					test_flags(state, BufferStateFlag::shader_write_ps))
 				{
 					flags |= VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
 				}
@@ -460,7 +464,8 @@ namespace Luna
 					flags |= VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
 				}
 				if (test_flags(state, BufferStateFlag::uniform_buffer_ps) ||
-					test_flags(state, BufferStateFlag::shader_read_ps))
+					test_flags(state, BufferStateFlag::shader_read_ps) ||
+					test_flags(state, BufferStateFlag::shader_write_ps))
 				{
 					flags |= VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
 				}
@@ -484,7 +489,8 @@ namespace Luna
 					flags |= VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
 				}
 				if (test_flags(state, BufferStateFlag::uniform_buffer_ps) ||
-					test_flags(state, BufferStateFlag::shader_read_ps))
+					test_flags(state, BufferStateFlag::shader_read_ps) ||
+					test_flags(state, BufferStateFlag::shader_write_ps))
 				{
 					flags |= VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
 				}
@@ -523,7 +529,8 @@ namespace Luna
 				{
 					flags |= VK_PIPELINE_STAGE_VERTEX_SHADER_BIT;
 				}
-				if (test_flags(state, TextureStateFlag::shader_read_ps))
+				if (test_flags(state, TextureStateFlag::shader_read_ps) ||
+					test_flags(state, TextureStateFlag::shader_write_ps))
 				{
 					flags |= VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
 				}
@@ -551,7 +558,8 @@ namespace Luna
 				{
 					flags |= VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
 				}
-				if (test_flags(state, TextureStateFlag::shader_read_ps))
+				if (test_flags(state, TextureStateFlag::shader_read_ps) ||
+					test_flags(state, TextureStateFlag::shader_write_ps))
 				{
 					flags |= VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
 				}
@@ -578,7 +586,8 @@ namespace Luna
 				{
 					flags |= VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
 				}
-				if (test_flags(state, TextureStateFlag::shader_read_ps))
+				if (test_flags(state, TextureStateFlag::shader_read_ps) ||
+					test_flags(state, TextureStateFlag::shader_write_ps))
 				{
 					flags |= VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
 				}

--- a/Modules/Luna/RHI/Source/Vulkan/Device.cpp
+++ b/Modules/Luna/RHI/Source/Vulkan/Device.cpp
@@ -39,6 +39,8 @@ namespace Luna
 			m_desc_pool_mtx = new_mutex();
 			m_physical_device = physical_device;
 			vkGetPhysicalDeviceProperties(physical_device, &m_physical_device_properties);
+			// Check device features.
+			vkGetPhysicalDeviceFeatures(physical_device, &m_physical_device_features);
 			// Create queues for every valid queue family.
 			Vector<VkDeviceQueueCreateInfo> queue_create_infos;
 			for (usize i = 0; i < queue_families.size(); ++i)
@@ -55,10 +57,6 @@ namespace Luna
 				create_info.flags = 0;
 				queue_create_infos.push_back(create_info);
 			}
-			// Check device features.
-			//vkGetPhysicalDeviceMemoryProperties(physical_device, &m_memory_properties);
-			VkPhysicalDeviceFeatures device_features{};
-			vkGetPhysicalDeviceFeatures(physical_device, &device_features);
 			
 			// Create device.
 			VkDeviceCreateInfo create_info{};
@@ -66,7 +64,7 @@ namespace Luna
 			create_info.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
 			create_info.pQueueCreateInfos = queue_create_infos.data();
 			create_info.queueCreateInfoCount = (u32)queue_create_infos.size();
-			create_info.pEnabledFeatures = &device_features;	// Enable all supported features.
+			create_info.pEnabledFeatures = &m_physical_device_features;	// Enable all supported features.
 			create_info.enabledLayerCount = g_enabled_layers.size();	// Enable all layers specified when creating VkInstance.
 			create_info.ppEnabledLayerNames = g_enabled_layers.data();
 			create_info.enabledExtensionCount = (u32)enabled_extensions.size();
@@ -263,8 +261,8 @@ namespace Luna
 		{
 			switch (feature)
 			{
-			case DeviceFeature::unbound_descriptor_array:
-				return false;
+			case DeviceFeature::unbound_descriptor_array: return false;
+			case DeviceFeature::pixel_shader_write: return m_physical_device_features.fragmentStoresAndAtomics == VK_TRUE;
 			}
 			return false;
 		}

--- a/Modules/Luna/RHI/Source/Vulkan/Device.hpp
+++ b/Modules/Luna/RHI/Source/Vulkan/Device.hpp
@@ -41,6 +41,7 @@ namespace Luna
 
 			// Features.
 			//VkPhysicalDeviceMemoryProperties m_memory_properties;
+			VkPhysicalDeviceFeatures m_physical_device_features;
 			VkPhysicalDeviceProperties m_physical_device_properties;
 
 			// Descriptor Pools.


### PR DESCRIPTION
This pull request implements pixel shader write and atomic operations in RHI. Before the user uses pixel shader write and atomic operations, she must check `DeviceFeature::pixel_shader_write` to ensure this is supported by the driver.