### PR TITLE
Fix some unsupported pipeline state settings for Metal

### DIFF
--- a/Modules/Luna/ImGui/Source/ImGui.cpp
+++ b/Modules/Luna/ImGui/Source/ImGui.cpp
@@ -611,7 +611,6 @@ float4 main(PS_INPUT input) : SV_Target
             {
                 GraphicsPipelineStateDesc ps_desc;
                 ps_desc.primitive_topology = PrimitiveTopology::triangle_list;
-                ps_desc.sample_mask = U32_MAX;
                 ps_desc.blend_state = BlendDesc({ AttachmentBlendDesc(true, BlendFactor::src_alpha,
                     BlendFactor::one_minus_src_alpha, BlendOp::add, BlendFactor::one_minus_src_alpha, BlendFactor::zero, BlendOp::add, ColorWriteMask::all) });
                 ps_desc.rasterizer_state = RasterizerDesc(FillMode::solid, CullMode::none, 0, 0.0f, 0.0f, false, true);

--- a/Modules/Luna/RHI/PipelineState.hpp
+++ b/Modules/Luna/RHI/PipelineState.hpp
@@ -140,7 +140,7 @@ namespace Luna
 			BlendFactor src_blend_alpha;
 			BlendFactor dst_blend_alpha;
 			BlendOp blend_op_alpha;
-			ColorWriteMask render_target_write_mask;
+			ColorWriteMask color_write_mask;
 
 			AttachmentBlendDesc(
 				bool blend_enable = false,
@@ -150,7 +150,7 @@ namespace Luna
 				BlendFactor src_blend_alpha = BlendFactor::one,
 				BlendFactor dst_blend_alpha = BlendFactor::zero,
 				BlendOp blend_op_alpha = BlendOp::add,
-				ColorWriteMask render_target_write_mask = ColorWriteMask::all
+				ColorWriteMask color_write_mask = ColorWriteMask::all
 			) :
 				blend_enable(blend_enable),
 				src_blend_color(src_blend_color),
@@ -159,7 +159,7 @@ namespace Luna
 				src_blend_alpha(src_blend_alpha),
 				dst_blend_alpha(dst_blend_alpha),
 				blend_op_alpha(blend_op_alpha),
-				render_target_write_mask(render_target_write_mask) {}
+				color_write_mask(color_write_mask) {}
 		};
 
 		struct BlendDesc
@@ -304,6 +304,7 @@ namespace Luna
 
 		enum class IndexBufferStripCutValue : u8
 		{
+			//! This should be set if primitive topology is not strip.
 			disabled,
 			//! This should be set if the index type is `Format::r16_uint`.
 			value_0xffff,
@@ -337,7 +338,6 @@ namespace Luna
 			Format depth_stencil_format = Format::unknown;
 			//! Specify the sample count, 1 if MSAA is not used.
 			u32 sample_count = 1;
-			u32 sample_mask = 0xFFFFFFFF;
 		};
 
 		//! @interface IPipelineState

--- a/Modules/Luna/RHI/Source/D3D12/PipelineState.cpp
+++ b/Modules/Luna/RHI/Source/D3D12/PipelineState.cpp
@@ -110,31 +110,31 @@ namespace Luna
 			dst.pShaderBytecode = src.data();
 		}
 
-		inline void encode_target_blend_desc(D3D12_RENDER_TARGET_BLEND_DESC& rt, const AttachmentBlendDesc& srt)
+		inline void encode_target_blend_desc(D3D12_RENDER_TARGET_BLEND_DESC& rt, const AttachmentBlendDesc& src)
 		{
-			rt.BlendEnable = srt.blend_enable ? TRUE : FALSE;
+			rt.BlendEnable = src.blend_enable ? TRUE : FALSE;
 			rt.LogicOpEnable = FALSE;
-			rt.SrcBlend = encode_blend_factor(srt.src_blend_color);
-			rt.DestBlend = encode_blend_factor(srt.dst_blend_color);
-			rt.BlendOp = encode_blend_op(srt.blend_op_color);
-			rt.SrcBlendAlpha = encode_blend_factor(srt.src_blend_alpha);
-			rt.DestBlendAlpha = encode_blend_factor(srt.dst_blend_alpha);
-			rt.BlendOpAlpha = encode_blend_op(srt.blend_op_alpha);
+			rt.SrcBlend = encode_blend_factor(src.src_blend_color);
+			rt.DestBlend = encode_blend_factor(src.dst_blend_color);
+			rt.BlendOp = encode_blend_op(src.blend_op_color);
+			rt.SrcBlendAlpha = encode_blend_factor(src.src_blend_alpha);
+			rt.DestBlendAlpha = encode_blend_factor(src.dst_blend_alpha);
+			rt.BlendOpAlpha = encode_blend_op(src.blend_op_alpha);
 			rt.LogicOp = D3D12_LOGIC_OP_NOOP;
 			rt.RenderTargetWriteMask = 0;
-			if ((srt.render_target_write_mask & ColorWriteMask::red) != ColorWriteMask::none)
+			if ((src.color_write_mask & ColorWriteMask::red) != ColorWriteMask::none)
 			{
 				rt.RenderTargetWriteMask = rt.RenderTargetWriteMask | D3D12_COLOR_WRITE_ENABLE_RED;
 			}
-			if ((srt.render_target_write_mask & ColorWriteMask::green) != ColorWriteMask::none)
+			if ((src.color_write_mask & ColorWriteMask::green) != ColorWriteMask::none)
 			{
 				rt.RenderTargetWriteMask = rt.RenderTargetWriteMask | D3D12_COLOR_WRITE_ENABLE_GREEN;
 			}
-			if ((srt.render_target_write_mask & ColorWriteMask::blue) != ColorWriteMask::none)
+			if ((src.color_write_mask & ColorWriteMask::blue) != ColorWriteMask::none)
 			{
 				rt.RenderTargetWriteMask = rt.RenderTargetWriteMask | D3D12_COLOR_WRITE_ENABLE_BLUE;
 			}
-			if ((srt.render_target_write_mask & ColorWriteMask::alpha) != ColorWriteMask::none)
+			if ((src.color_write_mask & ColorWriteMask::alpha) != ColorWriteMask::none)
 			{
 				rt.RenderTargetWriteMask = rt.RenderTargetWriteMask | D3D12_COLOR_WRITE_ENABLE_ALPHA;
 			}
@@ -173,7 +173,7 @@ namespace Luna
 						encode_target_blend_desc(d.BlendState.RenderTarget[i], desc.blend_state.attachments[0]);
 					}
 				}
-				d.SampleMask = desc.sample_mask;
+				d.SampleMask = 0xFFFFFFFF;
 			}
 			{
 				switch (desc.rasterizer_state.fill_mode)

--- a/Modules/Luna/RHI/Source/Vulkan/PipelineState.cpp
+++ b/Modules/Luna/RHI/Source/Vulkan/PipelineState.cpp
@@ -175,7 +175,8 @@ namespace Luna
 				multisampling.rasterizationSamples = encode_sample_count((u8)desc.sample_count);
 				multisampling.sampleShadingEnable = VK_FALSE;
 				multisampling.minSampleShading = 0.0f;
-				multisampling.pSampleMask = &desc.sample_mask;
+				u32 sample_mask = 0xFFFFFFFF;
+				multisampling.pSampleMask = &sample_mask;
 				multisampling.alphaToCoverageEnable = desc.blend_state.alpha_to_coverage_enable ? VK_TRUE : VK_FALSE;
 				multisampling.alphaToOneEnable = VK_FALSE;
 				create_info.pMultisampleState = &multisampling;
@@ -214,15 +215,19 @@ namespace Luna
 				for (usize i = 0; i < desc.num_color_attachments; ++i)
 				{
 					auto& dst = attachments[i];
-					auto& src = desc.blend_state.attachments[i];
-					dst.blendEnable = src.blend_enable ? VK_TRUE : VK_FALSE;
-					dst.srcColorBlendFactor = encode_blend_factor(src.src_blend_color);
-					dst.dstColorBlendFactor = encode_blend_factor(src.dst_blend_color);
-					dst.colorBlendOp = encode_blend_op(src.blend_op_color);
-					dst.srcAlphaBlendFactor = encode_blend_factor(src.src_blend_alpha);
-					dst.dstAlphaBlendFactor = encode_blend_factor(src.dst_blend_alpha);
-					dst.alphaBlendOp = encode_blend_op(src.blend_op_alpha);
-					dst.colorWriteMask = encode_color_component_flags(src.render_target_write_mask);
+					auto src = &desc.blend_state.attachments[i];
+					if(!desc.blend_state.independent_blend_enable)
+					{
+						src = &desc.blend_state.attachments[0];
+					}
+					dst.blendEnable = src->blend_enable ? VK_TRUE : VK_FALSE;
+					dst.srcColorBlendFactor = encode_blend_factor(src->src_blend_color);
+					dst.dstColorBlendFactor = encode_blend_factor(src->dst_blend_color);
+					dst.colorBlendOp = encode_blend_op(src->blend_op_color);
+					dst.srcAlphaBlendFactor = encode_blend_factor(src->src_blend_alpha);
+					dst.dstAlphaBlendFactor = encode_blend_factor(src->dst_blend_alpha);
+					dst.alphaBlendOp = encode_blend_op(src->blend_op_alpha);
+					dst.colorWriteMask = encode_color_component_flags(src->color_write_mask);
 				}
 				blend.pAttachments = attachments;
 				create_info.pColorBlendState = &blend;

--- a/Programs/Studio/RenderPasses/GeometryPass.cpp
+++ b/Programs/Studio/RenderPasses/GeometryPass.cpp
@@ -42,7 +42,6 @@ namespace Luna
 
 			GraphicsPipelineStateDesc ps_desc;
 			ps_desc.primitive_topology = PrimitiveTopology::triangle_list;
-			ps_desc.sample_mask = U32_MAX;
 			ps_desc.blend_state = BlendDesc({ AttachmentBlendDesc(true, BlendFactor::one, BlendFactor::zero, BlendOp::add, BlendFactor::one, BlendFactor::zero, BlendOp::add, ColorWriteMask::all) });
 			ps_desc.rasterizer_state = RasterizerDesc(FillMode::solid, CullMode::back, 0, 0.0f, 0.0f, false, true);
 			ps_desc.depth_stencil_state = DepthStencilDesc(true, true, CompareFunction::less_equal, false, 0x00, 0x00, DepthStencilOpDesc(), DepthStencilOpDesc());

--- a/Programs/Studio/RenderPasses/WireframePass.cpp
+++ b/Programs/Studio/RenderPasses/WireframePass.cpp
@@ -68,7 +68,6 @@ namespace Luna
 
 			GraphicsPipelineStateDesc ps_desc;
 			ps_desc.primitive_topology = PrimitiveTopology::triangle_list;
-			ps_desc.sample_mask = U32_MAX;
 			ps_desc.blend_state = BlendDesc({ AttachmentBlendDesc(true, BlendFactor::src_alpha,
 				BlendFactor::one_minus_src_alpha, BlendOp::add, BlendFactor::one, BlendFactor::zero, BlendOp::add, ColorWriteMask::all) });
 			ps_desc.rasterizer_state = RasterizerDesc(FillMode::wireframe, CullMode::none, 0.0f, 0.0f, 0.0f, false, true);

--- a/Tests/RHITests/RHITest4_Box/main.cpp
+++ b/Tests/RHITests/RHITest4_Box/main.cpp
@@ -133,7 +133,6 @@ RV start()
             PipelineLayoutFlag::allow_input_assembler_input_layout)));
         GraphicsPipelineStateDesc ps_desc;
         ps_desc.primitive_topology = PrimitiveTopology::triangle_list;
-		ps_desc.sample_mask = U32_MAX;
 		ps_desc.blend_state = BlendDesc({ 
             AttachmentBlendDesc(false, BlendFactor::src_alpha, BlendFactor::one_minus_src_alpha, BlendOp::add, BlendFactor::one_minus_src_alpha, BlendFactor::zero, BlendOp::add, ColorWriteMask::all) });
 		ps_desc.rasterizer_state = RasterizerDesc(FillMode::solid, CullMode::back, 0, 0.0f, 0.0f, false, true);


### PR DESCRIPTION
[RHI]Remove `sample_mask` property of `GraphicsPipelineStateDesc` because it is not supported on Metal.
[RHI]Add support for `independent_blend_enable` and `color_write_mask` of `AttachmentBlendDesc` for Metal.