### PR TITLE
XML serialization/deserialization support

### DIFF
--- a/Modules/Luna/Runtime/Unicode.hpp
+++ b/Modules/Luna/Runtime/Unicode.hpp
@@ -192,15 +192,13 @@ namespace Luna
 	}
 
 	//! Encodes the Unicode character `ch` into 1~2 `c16` bytes in the `dst` UTF-16 string.
-	//!  Returns the number of `c16` characters printed to the `dst` buffer.
-	//! @param[in] le If `true`, then the character is encoded using Little Endian, else the character
-	//! is encoded using Big Endian.
-	LUNA_RUNTIME_API usize utf16_encode_char(c16* dst, c32 ch, bool le = true);
+	//! Returns the number of `c16` characters printed to the `dst` buffer.
+	LUNA_RUNTIME_API usize utf16_encode_char(c16* dst, c32 ch);
 
-	//! Returns the Unicode character in the UTF-16 string `str`. LE and BE are automatic detected.
+	//! Returns the Unicode character in the UTF-16 string `str`.
 	LUNA_RUNTIME_API c32 utf16_decode_char(const c16* str);
 
-	//! Convert a utf-16 string to utf-8 string in destination buffer. LE and BE are automatic detected.
+	//! Convert a utf-16 string to utf-8 string in destination buffer.
 	//! @param[in] dst The buffer to hold the output string.
 	//! @param[in] dst_max_chars The maximum characters the `dst` buffer can hold, 
 	//! including the null-terminator.
@@ -220,14 +218,12 @@ namespace Luna
 	//! @param[in] dst_max_chars The maximum characters the `dst` buffer can hold, 
 	//! including the null-terminator.
 	//! @param[in] src The null-terminated buffer holding the source string.
-	//! @param[in] le If `true`, then the characters are encoded using Little Endian, else the characters
-	//! are encoded using Big Endian.
 	//! @param[in] src_chars The maximum characters to read. Specify `USIZE_MAX` to read till the end of the 
 	//! string.
 	//! @return Returns the number of characters outputted to the `dst` buffer, 
 	//! not including the null-terminator. Returns (usize)-1 if the input string is not
 	//! in utf-8 format.
-	LUNA_RUNTIME_API usize utf8_to_utf16(c16* dst, usize dst_max_chars, const c8* src, usize src_chars = USIZE_MAX, bool le = true);
+	LUNA_RUNTIME_API usize utf8_to_utf16(c16* dst, usize dst_max_chars, const c8* src, usize src_chars = USIZE_MAX);
 
 	//! Determines the length of the corresponding utf-16 string for a utf-8 input string,
 	//! not include the null-terminator.

--- a/Modules/Luna/VariantUtils/Source/JSON.cpp
+++ b/Modules/Luna/VariantUtils/Source/JSON.cpp
@@ -173,10 +173,7 @@ namespace Luna
 				}
 				c8 buf[6];
 				usize buf_count = utf8_encode_char(buf, ch);
-				for (usize i = 0; i < buf_count; ++i)
-				{
-					s.push_back(buf[i]);
-				}
+				s.append(buf, buf_count);
 				ctx.consume(ch);
 				ch = ctx.next_char();
 			}
@@ -586,11 +583,6 @@ namespace Luna
 						}
 						write_string_value(s, i.first.c_str(), i.first.size());
 						s.push_back(':');
-						//if (indent && (i.second.type() == VariantType::array || i.second.type() == VariantType::object) && !i.second.empty())
-						//{
-						//	s.push_back('\n');
-						//	write_indents(s, base_indent);
-						//}
 						if (indent)
 						{
 							s.push_back(' ');
@@ -621,29 +613,11 @@ namespace Luna
 				else
 				{
 					s.push_back('[');
-					//if (indent)
-					//{
-					//	++base_indent;
-					//	s.push_back('\n');
-					//}
 					for (usize i = 0; i < v.size(); ++i)
 					{
-						/*if (indent)
-						{
-							write_indents(s, base_indent);
-						}*/
 						write_value(v[i], s, indent, base_indent);
 						if (i != v.size() - 1) s.push_back(',');
-						/*if (indent)
-						{
-							s.push_back('\n');
-						}*/
 					}
-					//if (indent)
-					//{
-					//	--base_indent;
-					//	write_indents(s, base_indent);
-					//}
 					s.push_back(']');
 				}
 			}
@@ -679,11 +653,13 @@ namespace Luna
 		{
 			lucheck(src);
 			BufferReadContext ctx;
-			ctx.src = src;
+            ctx.src = src;
 			ctx.cur = src;
-			ctx.src_length = src_size;
+			ctx.src_size = src_size;
 			ctx.line = 1;
 			ctx.pos = 1;
+            ctx.encoding = Encoding::utf_8;
+			ctx.skip_utf16_bom();
 			return read_value(ctx);
 		}
 		LUNA_VARIANT_UTILS_API R<Variant> read_json(IStream* stream)

--- a/Modules/Luna/VariantUtils/Source/StringParser.cpp
+++ b/Modules/Luna/VariantUtils/Source/StringParser.cpp
@@ -79,10 +79,10 @@ namespace Luna
 					c32 ch = utf8_decode_char(next_cur);
 					if (!ch) return 0;
 					next_cur += utf8_charspan(ch);
-					if ((usize)(next_cur - src) >= src_length) return 0;
+					if ((usize)(next_cur - src) >= src_size) return 0;
 					--index;
 				}
-				if ((usize)(next_cur - src) >= src_length) return 0;
+				if ((usize)(next_cur - src) >= src_size) return 0;
 				return utf8_decode_char(next_cur);
 			}
 			else if(encoding == Encoding::utf_16_le || encoding == Encoding::utf_16_be)
@@ -95,12 +95,33 @@ namespace Luna
 					c32 ch = utf16_decode_char_encoding(next_cur, encoding);
 					if (!ch) return 0;
 					next_cur += utf16_charspan(ch);
-					if ((usize)(next_cur - src) * 2 >= src_length) return 0;
+					if ((usize)(next_cur - src) * 2 >= src_size) return 0;
 					--index;
 				}
-				if ((usize)(next_cur - src) * 2 >= src_length) return 0;
+				if ((usize)(next_cur - src) * 2 >= src_size) return 0;
 				return utf16_decode_char_encoding(next_cur, encoding);
 			}
+		}
+		void BufferReadContext::skip_utf16_bom()
+		{
+			if(src_size >= 2)
+            {
+                const u8* ch = (const u8*)src;
+                if(ch[0] == 0xFE && ch[1] == 0xFF)
+                {
+                    encoding = Encoding::utf_16_be;
+                    src = ch + 2;
+                    cur = ch + 2;
+                    src_size -= 2;
+                }
+                else if(ch[0] == 0xFF && ch[1] == 0xFE)
+                {
+                    encoding = Encoding::utf_16_le;
+                    src = ch + 2;
+                    cur = ch + 2;
+                    src_size -= 2;
+                }
+            }
 		}
         void StreamReadContext::consume(c32 ch)
         {
@@ -116,6 +137,31 @@ namespace Luna
 				++pos;
 			}
 		}
+		RV StreamReadContext::stream_read(void* buf, usize read_size, usize* read_bytes)
+		{
+			usize real_read_bytes = 0;
+			u8* buf_u8 = (u8*)buf;
+			while(read_size && !stream_buffer.empty())
+			{
+				*buf_u8 = stream_buffer.front();
+				stream_buffer.pop_front();
+				++buf_u8;
+				++real_read_bytes;
+				--read_size;
+			}
+			lutry
+			{
+				if(read_size)
+				{
+					usize stream_read_bytes;
+					luexp(stream->read(buf_u8, read_size, &stream_read_bytes));
+					real_read_bytes += stream_read_bytes;
+				}
+			}
+			lucatchret;
+			if(read_bytes) *read_bytes = real_read_bytes;
+			return ok;
+		}
         R<c32> StreamReadContext::read_one_char_from_stream()
 		{
 			c32 ret;
@@ -125,12 +171,12 @@ namespace Luna
 				{
 					c8 buf[6];
 					usize read_bytes;
-					luexp(stream->read(buf, sizeof(c8), &read_bytes));
+					luexp(stream_read(buf, sizeof(c8), &read_bytes));
 					if (read_bytes != sizeof(c8)) return 0;
 					usize charspan = utf8_charlen(buf[0]);
 					if (charspan > 1)
 					{
-						luexp(stream->read((buf + 1), sizeof(c8) * (charspan - 1), &read_bytes));
+						luexp(stream_read((buf + 1), sizeof(c8) * (charspan - 1), &read_bytes));
 						if (read_bytes != sizeof(c8) * (charspan - 1)) return 0;
 					}
 					ret = utf8_decode_char(buf);
@@ -139,13 +185,13 @@ namespace Luna
 				{
 					c16 buf[2];
 					usize read_bytes;
-					luexp(stream->read(buf, sizeof(c16), &read_bytes));
+					luexp(stream_read(buf, sizeof(c16), &read_bytes));
 					if (read_bytes != sizeof(c16)) return 0;
 					buf[0] = utf16_read_char(buf[0], encoding);
 					usize charspan = utf16_charlen(buf[0]);
 					if (charspan > 1)
 					{
-						luexp(stream->read((buf + 1), sizeof(c16) * (charspan - 1), &read_bytes));
+						luexp(stream_read((buf + 1), sizeof(c16) * (charspan - 1), &read_bytes));
 						if (read_bytes != sizeof(c16) * (charspan - 1)) return 0;
 						buf[1] = utf16_read_char(buf[1], encoding);
 					}
@@ -164,6 +210,33 @@ namespace Luna
 				buffer.push_back(ch.get());
 			}
 			return buffer[index];
+		}
+		void StreamReadContext::skip_utf16_bom()
+		{
+			u8 ch[2];
+			usize read_bytes;
+			auto r = stream->read(ch, 2, &read_bytes);
+			if(failed(r) || read_bytes != 2)
+			{
+				if(read_bytes)
+				{
+					stream_buffer.push_back(ch[0]);
+				}
+				return;
+			}
+			if(ch[0] == 0xFE && ch[1] == 0xFF)
+			{
+				encoding = Encoding::utf_16_be;
+			}
+			else if(ch[0] == 0xFF && ch[1] == 0xFE)
+			{
+				encoding = Encoding::utf_16_le;
+			}
+			else
+			{
+				stream_buffer.push_back(ch[0]);
+				stream_buffer.push_back(ch[1]);
+			}
 		}
     }
 }

--- a/Modules/Luna/VariantUtils/Source/StringParser.cpp
+++ b/Modules/Luna/VariantUtils/Source/StringParser.cpp
@@ -79,10 +79,10 @@ namespace Luna
 					c32 ch = utf8_decode_char(next_cur);
 					if (!ch) return 0;
 					next_cur += utf8_charspan(ch);
-					if ((usize)(next_cur - src) >= src_size) return 0;
+					if ((usize)(next_cur - (const c8*)src) >= src_size) return 0;
 					--index;
 				}
-				if ((usize)(next_cur - src) >= src_size) return 0;
+				if ((usize)(next_cur - (const c8*)src) >= src_size) return 0;
 				return utf8_decode_char(next_cur);
 			}
 			else if(encoding == Encoding::utf_16_le || encoding == Encoding::utf_16_be)
@@ -95,10 +95,10 @@ namespace Luna
 					c32 ch = utf16_decode_char_encoding(next_cur, encoding);
 					if (!ch) return 0;
 					next_cur += utf16_charspan(ch);
-					if ((usize)(next_cur - src) * 2 >= src_size) return 0;
+					if ((usize)(next_cur - (const c16*)src) * 2 >= src_size) return 0;
 					--index;
 				}
-				if ((usize)(next_cur - src) * 2 >= src_size) return 0;
+				if ((usize)(next_cur - (const c16*)src) * 2 >= src_size) return 0;
 				return utf16_decode_char_encoding(next_cur, encoding);
 			}
 		}

--- a/Modules/Luna/VariantUtils/Source/StringParser.hpp
+++ b/Modules/Luna/VariantUtils/Source/StringParser.hpp
@@ -18,6 +18,12 @@ namespace Luna
     namespace VariantUtils
     {
         // The common function for parsing string content (JSON, XML, etc).
+		enum class Encoding : u8
+		{
+			utf_8 = 0,
+			utf_16_le = 1,
+			utf_16_be = 2,
+		};
 
         inline bool is_whitespace(c32 ch)
 		{
@@ -42,8 +48,9 @@ namespace Luna
         // A buffer read context
         struct BufferReadContext : public IReadContext
 		{
-			const c8* src;
-			const c8* cur;
+			Encoding encoding = Encoding::utf_8;
+			const void* src;
+			const void* cur;
 			usize src_length;
 			u32 line;
 			u32 pos;
@@ -57,6 +64,7 @@ namespace Luna
         // A stream read context
         struct StreamReadContext : public IReadContext
 		{
+			Encoding encoding = Encoding::utf_8;
 			IStream* stream;
 			RingDeque<c32> buffer;
 			u32 line;

--- a/Modules/Luna/VariantUtils/Source/StringParser.hpp
+++ b/Modules/Luna/VariantUtils/Source/StringParser.hpp
@@ -51,7 +51,7 @@ namespace Luna
 			Encoding encoding = Encoding::utf_8;
 			const void* src;
 			const void* cur;
-			usize src_length;
+			usize src_size;
 			u32 line;
 			u32 pos;
 
@@ -59,6 +59,8 @@ namespace Luna
 			virtual c32 next_char(usize index = 0) override;
 			virtual u32 get_line() override { return line; }
 			virtual u32 get_pos() override { return pos; }
+
+			void skip_utf16_bom();
 		};
 
         // A stream read context
@@ -66,6 +68,7 @@ namespace Luna
 		{
 			Encoding encoding = Encoding::utf_8;
 			IStream* stream;
+			RingDeque<u8> stream_buffer;
 			RingDeque<c32> buffer;
 			u32 line;
 			u32 pos;
@@ -76,6 +79,10 @@ namespace Luna
 			virtual c32 next_char(usize index = 0) override;
 			virtual u32 get_line() override { return line; }
 			virtual u32 get_pos() override { return pos; }
+
+			RV stream_read(void* buf, usize read_size, usize* read_bytes);
+
+			void skip_utf16_bom();
 		};
     }
 }

--- a/Modules/Luna/VariantUtils/Source/VariantUtils.cpp
+++ b/Modules/Luna/VariantUtils/Source/VariantUtils.cpp
@@ -15,18 +15,15 @@ namespace Luna
     {
         void xml_init();
         void xml_close();
-    }
-    RV init()
-    {
-        VariantUtils::xml_init();
-        return ok;
-    }
-    void close()
-    {
-        VariantUtils::xml_close();
-    }
-    namespace VariantUtils
-    {
+        RV init()
+        {
+            VariantUtils::xml_init();
+            return ok;
+        }
+        void close()
+        {
+            VariantUtils::xml_close();
+        }
         LUNA_STATIC_REGISTER_MODULE(VariantUtils, "", init, close);
     }
 }

--- a/Modules/Luna/VariantUtils/Source/VariantUtils.cpp
+++ b/Modules/Luna/VariantUtils/Source/VariantUtils.cpp
@@ -13,6 +13,20 @@ namespace Luna
 {
     namespace VariantUtils
     {
-        LUNA_STATIC_REGISTER_MODULE(VariantUtils, "", nullptr, nullptr);
+        void xml_init();
+        void xml_close();
+    }
+    RV init()
+    {
+        VariantUtils::xml_init();
+        return ok;
+    }
+    void close()
+    {
+        VariantUtils::xml_close();
+    }
+    namespace VariantUtils
+    {
+        LUNA_STATIC_REGISTER_MODULE(VariantUtils, "", init, close);
     }
 }

--- a/Modules/Luna/VariantUtils/Source/XML.cpp
+++ b/Modules/Luna/VariantUtils/Source/XML.cpp
@@ -1,0 +1,690 @@
+/*!
+* This file is a portion of Luna SDK.
+* For conditions of distribution and use, see the disclaimer
+* and license in LICENSE.txt
+* 
+* @file XML.cpp
+* @author JXMaster
+* @date 2023/10/12
+*/
+#include <Luna/Runtime/PlatformDefines.hpp>
+#define LUNA_VARIANT_UTILS_API LUNA_EXPORT
+#include "../XML.hpp"
+#include "StringParser.hpp"
+
+namespace Luna
+{
+    namespace VariantUtils
+    {
+        Name _name;
+        Name _attributes;
+        Name _content;
+        void xml_init()
+        {
+            _name = "name";
+            _attributes = "attributes";
+            _content = "content";
+        }
+        void xml_close()
+        {
+            _name.reset();
+            _attributes.reset();
+            _content.reset();
+        }
+        LUNA_VARIANT_UTILS_API Variant new_xml_element(const Name& name)
+        {
+            Variant element(VariantType::object);
+            element[_name] = name;
+            element[_attributes] = Variant(VariantType::object);
+            element[_content] = Variant(VariantType::array);
+            return element;
+        }
+        LUNA_VARIANT_UTILS_API const Variant& get_xml_content(const Variant& xml_element)
+        {
+            return xml_element[_content];
+        }
+        LUNA_VARIANT_UTILS_API Name get_xml_name(const Variant& xml_element)
+        {
+            return xml_element[_name].str();
+        }
+        LUNA_VARIANT_UTILS_API void set_xml_name(Variant& xml_element, const Name& name)
+        {
+            xml_element[_name] = name;
+        }
+        LUNA_VARIANT_UTILS_API const Variant& get_xml_attributes(const Variant& xml_element)
+        {
+            return xml_element[_attributes];
+        }
+		LUNA_VARIANT_UTILS_API Variant& get_xml_attributes(Variant& xml_element)
+        {
+            return xml_element[_attributes];
+        }
+        LUNA_VARIANT_UTILS_API Variant& get_xml_content(Variant& xml_element)
+        {
+            return xml_element[_content];
+        }
+        static void skip_single_line_comment(IReadContext& ctx)
+        {
+            lucheck(ctx.next_char() == '<' && ctx.next_char(1) == '!' && ctx.next_char(2) == '-' && ctx.next_char(3) == '-');
+            ctx.consume('<');
+			ctx.consume('!');
+            ctx.consume('-');
+            ctx.consume('-');
+            c32 ch = ctx.next_char();
+            while(ch)
+            {
+                if(ch == '-')
+                {
+                    c32 chs[2];
+                    chs[0] = ctx.next_char(1);
+                    chs[1] = ctx.next_char(2);
+                    if(chs[0] == '-' && chs[1] == '>')
+                    {
+                        ctx.consume('-');
+                        ctx.consume('-');
+                        ctx.consume('>');
+                        return;
+                    }
+                }
+                ctx.consume(ch);
+                ch = ctx.next_char();
+            }
+        }
+        static void skip_whitespaces_and_comments(IReadContext& ctx)
+        {
+            c32 ch = ctx.next_char();
+			while (ch)
+			{
+				if (is_whitespace(ch))
+				{
+					ctx.consume(ch);
+				}
+				else if (ch == '<')
+				{
+					c32 chs[3];
+                    chs[0] = ctx.next_char(1);
+                    chs[1] = ctx.next_char(2);
+                    chs[2] = ctx.next_char(3);
+                    if(chs[0] == '!' && chs[1] == '-' && chs[2] == '-')
+                    {
+                        skip_single_line_comment(ctx);
+                    }
+					else
+					{
+						break;
+					}
+				}
+				else break;
+				ch = ctx.next_char();
+			}
+        }
+        static RV skip_xml_header(IReadContext& ctx)
+        {
+            // <?xml version="1.0" encoding="UTF-8"?>
+            skip_whitespaces_and_comments(ctx);
+            c32 chs[5];
+            chs[0] = ctx.next_char(0);
+            chs[1] = ctx.next_char(1);
+            chs[2] = ctx.next_char(2);
+            chs[3] = ctx.next_char(3);
+            chs[4] = ctx.next_char(4);
+            if(!(
+                chs[0] == '<' &&
+                chs[1] == '?' &&
+                (chs[2] == 'x' || chs[2] == 'X') &&
+                (chs[3] == 'm' || chs[3] == 'M') &&
+                (chs[4] == 'l' || chs[4] == 'L')
+            ))
+            {
+                return set_error(BasicError::format_error(), "'<?xml' or '<?XML' expected at the beginning of the document (line %d pos %d).", ctx.get_line(), ctx.get_pos());
+            }
+            ctx.consume(chs[0]);
+            ctx.consume(chs[1]);
+            ctx.consume(chs[2]);
+            ctx.consume(chs[3]);
+            ctx.consume(chs[4]);
+            skip_whitespaces_and_comments(ctx);
+            // Currently we don't handle xml header data.
+            chs[0] = ctx.next_char(0);
+            while(chs[0])
+            {
+                if(chs[0] == '?')
+                {
+                    chs[1] = ctx.next_char(1);
+                    if(chs[1] == '>')
+                    {
+                        ctx.consume(chs[0]);
+                        ctx.consume(chs[1]);
+                        return ok;
+                    }
+                }
+                ctx.consume(chs[0]);
+                chs[0] = ctx.next_char(0);
+            }
+            return set_error(BasicError::format_error(), "Unexpected EOF occurred at line %d, pos %d.", ctx.get_line(), ctx.get_pos());
+        }
+        inline bool is_name_start_char(u32 ch)
+        {
+            return ch == ':' || 
+                (ch >= 'A' && ch <= 'Z') ||
+                ch == '_' ||
+                (ch >= 'a' && ch <= 'z') ||
+                (ch >= 0xC0 && ch <= 0xD6) ||
+                (ch >= 0xD8 && ch <= 0xF6) ||
+                (ch >= 0xF8 && ch <= 0x2FF) ||
+                (ch >= 0x370 && ch <= 0x37D) ||
+                (ch >= 0x37F && ch <= 0x1FFF) ||
+                (ch >= 0x200C && ch <= 0x200D) ||
+                (ch >= 0x2070 && ch <= 0x218F) ||
+                (ch >= 0x2C00 && ch <= 0x2FEF) ||
+                (ch >= 0x3001 && ch <= 0xD7FF) ||
+                (ch >= 0xF900 && ch <= 0xFDCF) ||
+                (ch >= 0xFDF0 && ch <= 0xFFFD) ||
+                (ch >= 0x10000 && ch <= 0xEFFFF);
+        }
+        inline bool is_name_char(u32 ch)
+        {
+            return is_name_start_char(ch) ||
+                ch == '-' ||
+                ch == '.' ||
+                (ch >= '0' && ch <= '9') ||
+                ch == 0xB7 ||
+                (ch >= 0x0300 && ch <= 0x036F) ||
+                (ch >= 0x203F && ch <= 0x2040);
+        }
+        static void read_xml_name(IReadContext& ctx, String& dst)
+        {
+            c32 ch = ctx.next_char();
+            if(!is_name_start_char((u32)ch))
+            {
+                return;
+            }
+            c8 utf8_buf[8];
+            usize size = utf8_encode_char(utf8_buf, ch);
+            dst.append(utf8_buf, size);
+            ctx.consume(ch);
+            ch = ctx.next_char();
+            while(is_name_char(ch))
+            {
+                size = utf8_encode_char(utf8_buf, ch);
+                dst.append(utf8_buf, size);
+                ctx.consume(ch);
+                ch = ctx.next_char();
+            }
+        }
+        inline bool is_hex(c32 ch)
+        {
+            u32 ch_num = (u32)ch;
+            return (ch_num >= '0' && ch_num <= '9') || (ch_num >= 'a' && ch_num <= 'f') || (ch_num >= 'A' && ch_num <= 'F'); 
+        }
+        inline u8 atohex(c32 ch)
+		{
+            u32 ch_num = (u32)ch;
+			return ch_num >= '0' && ch_num <= '9' ? ch_num - '0' :
+				ch_num >= 'a' && ch_num <= 'f' ? ch_num - 'a' + 10 :
+				ch_num >= 'A' && ch_num <= 'F' ? ch_num - 'A' + 10 : 0;
+		}
+        static RV read_reference(IReadContext& ctx, String& s)
+        {
+            c32 ch = ctx.next_char();
+            lucheck(ch == '&');
+            ctx.consume(ch);
+            ch = ctx.next_char();
+            if(ch == '#')
+            {
+                // character reference.
+                ctx.consume(ch);
+                ch = ctx.next_char();
+                u32 read_ch;
+                if(ch == 'x')
+                {
+                    // hex
+                    ctx.consume(ch);
+                    ch = ctx.next_char();
+                    if(!is_hex(ch))
+                    {
+                        return set_error(BasicError::format_error(), "Unexpected character. (line %d pos %d).", ctx.get_line(), ctx.get_pos());
+                    }
+                    read_ch = atohex(ch);
+                    ctx.consume(ch);
+                    ch = ctx.next_char();
+                    while(ch != ';')
+                    {
+                        if(!is_hex(ch))
+                        {
+                            return set_error(BasicError::format_error(), "Unexpected character. (line %d pos %d).", ctx.get_line(), ctx.get_pos());
+                        }
+                        read_ch = read_ch << 4 + atohex(ch);
+                        ctx.consume(ch);
+                        ch = ctx.next_char();
+                    }
+                }
+                else
+                {
+                    // decimal
+                    if((u32)ch < '0' || (u32)ch > '9')
+                    {
+                        return set_error(BasicError::format_error(), "Unexpected character. (line %d pos %d).", ctx.get_line(), ctx.get_pos());
+                    }
+                    read_ch = (u32)ch - '0';
+                    ctx.consume(ch);
+                    ch = ctx.next_char();
+                    while(ch != ';')
+                    {
+                        if((u32)ch < '0' || (u32)ch > '9')
+                        {
+                            return set_error(BasicError::format_error(), "Unexpected character. (line %d pos %d).", ctx.get_line(), ctx.get_pos());
+                        }
+                        read_ch = read_ch * 10 + ((u32)ch - '0');
+                        ctx.consume(ch);
+                        ch = ctx.next_char();
+                    }
+                }
+                ctx.consume(ch); // ;
+                c8 buf[6];
+                usize char_size = utf8_encode_char(buf, (c32)read_ch);
+                s.append(buf, char_size);
+            }
+            else
+            {
+                // entity reference.
+                c32 buf[5];
+                buf[0] = ctx.next_char(0);
+                buf[1] = ctx.next_char(1);
+                buf[2] = ctx.next_char(2);
+                buf[3] = ctx.next_char(3);
+                buf[4] = ctx.next_char(4);
+                if(buf[0] == 'a' && buf[1] == 'm' && buf[2] == 'p' && buf[3] == ';')
+                {
+                    s.push_back('&');
+                    ctx.consume(buf[0]);
+                    ctx.consume(buf[1]);
+                    ctx.consume(buf[2]);
+                    ctx.consume(buf[3]);
+                }
+                else if(buf[0] == 'l' && buf[1] == 't' && buf[2] == ';')
+                {
+                    s.push_back('<');
+                    ctx.consume(buf[0]);
+                    ctx.consume(buf[1]);
+                    ctx.consume(buf[2]);
+                }
+                else if(buf[0] == 'g' && buf[1] == 't' && buf[2] == ';')
+                {
+                    s.push_back('>');
+                    ctx.consume(buf[0]);
+                    ctx.consume(buf[1]);
+                    ctx.consume(buf[2]);
+                }
+                else if(buf[0] == 'a' && buf[1] == 'p' && buf[2] == 'o' && buf[3] == 's' && buf[4] == ';')
+                {
+                    s.push_back('\'');
+                    ctx.consume(buf[0]);
+                    ctx.consume(buf[1]);
+                    ctx.consume(buf[2]);
+                    ctx.consume(buf[3]);
+                    ctx.consume(buf[4]);
+                }
+                else if(buf[0] == 'q' && buf[1] == 'u' && buf[2] == 'o' && buf[3] == 't' && buf[4] == ';')
+                {
+                    s.push_back('"');
+                    ctx.consume(buf[0]);
+                    ctx.consume(buf[1]);
+                    ctx.consume(buf[2]);
+                    ctx.consume(buf[3]);
+                    ctx.consume(buf[4]);
+                }
+                else
+                {
+                    // does not match anything, proceed as normal strings.
+                    s.push_back('&');
+                }
+            }
+            return ok;
+        }
+        static R<String> read_xml_string_literal(IReadContext& ctx)
+		{
+			String s;
+            lutry
+            {
+                c32 ch = ctx.next_char();
+                lucheck(ch == '"' || ch == '\'');
+                ctx.consume(ch);
+                ch = ctx.next_char();
+                while (ch)
+                {
+                    if(ch == '&')
+                    {
+                        luexp(read_reference(ctx, s));
+                        ch = ctx.next_char();
+                    }
+                    if (ch == '"' || ch == '\'')
+                    {
+                        ctx.consume(ch);
+                        break;
+                    }
+                    c8 buf[6];
+                    usize buf_count = utf8_encode_char(buf, ch);
+                    s.append(buf, buf_count);
+                    ctx.consume(ch);
+                    ch = ctx.next_char();
+                }
+            }
+            lucatchret;
+			return s;
+		}
+        static R<String> read_xml_character_data(IReadContext& ctx)
+        {
+            String s;
+            lutry
+            {
+                c32 ch = ctx.next_char();
+                while (ch)
+                {
+                    if(ch == '<')
+                    {
+                        break;
+                    }
+                    if(ch == '&')
+                    {
+                        luexp(read_reference(ctx, s));
+                        ch = ctx.next_char();
+                    }
+                    c8 buf[6];
+                    usize buf_count = utf8_encode_char(buf, ch);
+                    s.append(buf, buf_count);
+                    ctx.consume(ch);
+                    ch = ctx.next_char();
+                }
+            }
+            lucatchret;
+            return s;
+        }
+        static R<Variant> read_xml_attribute(IReadContext& ctx, Name& attribute_name)
+        {
+            Variant ret;
+            lutry
+            {
+                String name;
+                read_xml_name(ctx, name);
+                if(name.empty()) return set_error(BasicError::format_error(), "Valid name character expected. (line %d pos %d).", ctx.get_line(), ctx.get_pos());
+                attribute_name = name;
+                skip_whitespaces_and_comments(ctx);
+                c32 ch = ctx.next_char();
+                if(ch != '=') return set_error(BasicError::format_error(), "'=' expected. (line %d pos %d).", ctx.get_line(), ctx.get_pos());
+                ctx.consume(ch);
+                skip_whitespaces_and_comments(ctx);
+                ch = ctx.next_char();
+                if(ch != '"' && ch != '\'') return set_error(BasicError::format_error(), "'\"' expected. (line %d pos %d).", ctx.get_line(), ctx.get_pos());
+                lulet(data, read_xml_string_literal(ctx));
+                ret = Name(data);
+            }
+            lucatchret;
+            return ret;
+        }
+        static RV read_xml_start_tag(IReadContext& ctx, Variant& element, Name& element_name, bool& empty_tag)
+        {
+            lutry
+            {
+                skip_whitespaces_and_comments(ctx);
+                c32 ch = ctx.next_char();
+                if(ch != '<')
+                {
+                    return set_error(BasicError::format_error(), "'<' expected at the beginning of one element (line %d pos %d).", ctx.get_line(), ctx.get_pos());
+                }
+                ctx.consume(ch);
+                String name;
+                read_xml_name(ctx, name);
+                if(name.empty()) return set_error(BasicError::format_error(), "Valid name character expected. (line %d pos %d).", ctx.get_line(), ctx.get_pos());
+                element_name = name;
+                element = new_xml_element(element_name);
+                skip_whitespaces_and_comments(ctx);
+                ch = ctx.next_char();
+                c32 ch2 = ctx.next_char(1);
+                Variant& attributes = get_xml_attributes(element);
+                while(ch != '>' && !(ch == '/' && ch2 == '>'))
+                {
+                    Name attribute_name;
+                    lulet(attribute, read_xml_attribute(ctx, attribute_name));
+                    attributes[attribute_name] = move(attribute);
+                    skip_whitespaces_and_comments(ctx);
+                    ch = ctx.next_char();
+                    ch2 = ctx.next_char(1);
+                }
+                if(ch == '>')
+                {
+                    empty_tag = false;
+                    ctx.consume(ch);
+                }
+                else
+                {
+                    empty_tag = true;
+                    ctx.consume(ch);
+                    ctx.consume(ch2);
+                }
+            }
+            lucatchret;
+            return ok;
+        }
+        static R<Variant> read_xml_element(IReadContext& ctx);
+        static RV read_xml_content(IReadContext& ctx, Variant& element)
+        {
+            lutry
+            {
+                Variant& content = get_xml_content(element);
+                skip_whitespaces_and_comments(ctx);
+                c32 ch = ctx.next_char();
+                while(true)
+                {
+                    if(!ch) return set_error(BasicError::format_error(), "Unexpected EOF occurred at line %d, pos %d.", ctx.get_line(), ctx.get_pos());
+                    if(ch == '<')
+                    {
+                        c32 ch2 = ctx.next_char(1);
+                        if(ch2 == '/')
+                        {
+                            // end tag.
+                            break;
+                        }
+                        lulet(child, read_xml_element(ctx));
+                        content.push_back(move(child));
+                    }
+                    else
+                    {
+                        lulet(chardata, read_xml_character_data(ctx));
+                        // discard trailing whitespaces.
+                        while (!chardata.empty() && is_whitespace((c32)chardata.back()))
+                        {
+                            chardata.pop_back();
+                        }
+                        content.push_back(Variant(Name(chardata)));
+                    }
+                    skip_whitespaces_and_comments(ctx);
+                    ch = ctx.next_char();
+                }
+            }
+            lucatchret;
+            return ok;
+        }
+        static RV read_xml_end_tag(IReadContext& ctx, const Name& element_name)
+        {
+            c32 ch = ctx.next_char();
+            c32 ch2 = ctx.next_char(1);
+            luassert(ch == '<' && ch2 == '/');
+            ctx.consume(ch);
+            ctx.consume(ch2);
+            String name;
+            read_xml_name(ctx, name);
+            if(Name(name) != element_name) return set_error(BasicError::format_error(), "The name of the end tag (%s) does not match the name of the start tag (%s). (line %d pos %d)", name.c_str(), element_name.c_str(), ctx.get_line(), ctx.get_pos());
+            skip_whitespaces_and_comments(ctx);
+            ch = ctx.next_char();
+            if(ch != '>') return set_error(BasicError::format_error(), "'>' expected at the end of one one tag (line %d pos %d).", ctx.get_line(), ctx.get_pos());
+            ctx.consume(ch);
+            return ok;
+        }
+        static R<Variant> read_xml_element(IReadContext& ctx)
+        {
+            Variant ret;
+            lutry
+            {
+                Name element_name;
+                bool empty_tag;
+                luexp(read_xml_start_tag(ctx, ret, element_name, empty_tag));
+                if(!empty_tag)
+                {
+                    luexp(read_xml_content(ctx, ret));
+                    luexp(read_xml_end_tag(ctx, element_name));
+                }
+            }
+            lucatchret;
+            return ret;
+        }
+        static R<Variant> read_xml_document(IReadContext& ctx)
+        {
+            lutry
+            {
+                luexp(skip_xml_header(ctx));
+            }
+            lucatchret;
+            return read_xml_element(ctx);
+        }
+        LUNA_VARIANT_UTILS_API R<Variant> read_xml(const void* src, usize src_size)
+        {
+            lucheck(src);
+			BufferReadContext ctx;
+            ctx.src = src;
+			ctx.cur = src;
+			ctx.src_size = src_size;
+			ctx.line = 1;
+			ctx.pos = 1;
+            ctx.encoding = Encoding::utf_8;
+            ctx.skip_utf16_bom();
+            return read_xml_document(ctx);
+        }
+		LUNA_VARIANT_UTILS_API R<Variant> read_xml(IStream* stream)
+        {
+            lucheck(stream);
+			StreamReadContext ctx;
+			ctx.stream = stream;
+			ctx.line = 1;
+			ctx.pos = 1;
+            ctx.skip_utf16_bom();
+			return read_xml_document(ctx);
+        }
+        inline void write_indents(String& s, u32 num_indents)
+		{
+			for (u32 i = 0; i < num_indents; ++i)
+			{
+				s.push_back('\t');
+			}
+		}
+        void write_xml_string(String& dst, const Name& str)
+        {
+            const c8* cur = str.c_str();
+			const c8* end = str.c_str() + str.size();
+			while (cur < end)
+			{
+				c32 ch = utf8_decode_char(cur);
+				switch (ch)
+				{
+				case '<':
+                    dst.append("&lt;");
+                    break;
+                case '>':
+                    dst.append("&gt;");
+                    break;
+                case '&':
+                    dst.append("&amp;");
+                    break;
+                case '"':
+                    dst.append("&quot;");
+                    break;
+                case '\'':
+                    dst.append("&apos;");
+                    break;
+                case '\n':
+                    dst.append("&#10;");
+                    break;
+                case '\r':
+                    dst.append("&#13;");
+                    break;
+                case '\t':
+                    dst.append("&#9;");
+                    break;
+				default:
+					dst.append(cur, utf8_charspan(ch));
+					break;
+				}
+				cur += utf8_charspan(ch);
+			}
+        }
+        void write_xml_element(const Variant& v, String& s, bool indent, u32 base_indent)
+        {
+            auto name = get_xml_name(v);
+            // start tag.
+            s.push_back('<');
+            s.append(name.c_str());
+            auto& attributes = get_xml_attributes(v);
+            for(auto& attr : attributes.key_values())
+            {
+                s.push_back(' ');
+                s.append(attr.first.c_str());
+                s.push_back('=');
+                s.push_back('"');
+                write_xml_string(s, attr.second.str());
+                s.push_back('"');
+            }
+            s.push_back('>');
+            auto& content = get_xml_content(v);
+            if(!content.empty())
+            {
+                bool single_chardata_content = content.size() == 1 && content.at(0).type() == VariantType::string;
+                if(indent && !single_chardata_content)
+                {
+                    ++base_indent;
+                    s.push_back('\n');
+                }
+                for(auto& child : content.values())
+                {
+                    if (indent && !single_chardata_content)
+					{
+						write_indents(s, base_indent);
+					}
+                    if(child.type() == VariantType::object)
+                    {
+                        write_xml_element(child, s, indent, base_indent);
+                    }
+                    else if(child.type() == VariantType::string)
+                    {
+                        write_xml_string(s, child.c_str());
+                    }
+                    if (indent && !single_chardata_content)
+					{
+						s.push_back('\n');
+					}
+                }
+                if (indent && !single_chardata_content)
+				{
+					--base_indent;
+					write_indents(s, base_indent);
+				}
+            }
+            // end tag.
+            s.push_back('<');
+            s.push_back('/');
+            s.append(name.c_str());
+            s.push_back('>');
+        }
+        LUNA_VARIANT_UTILS_API String write_xml(const Variant& v, bool indent)
+        {
+            String r("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
+            if(indent) r.push_back('\n');
+            write_xml_element(v, r, indent, 0);
+            return r;
+        }
+		LUNA_VARIANT_UTILS_API RV write_xml(IStream* stream, const Variant& v, bool indent)
+        {
+            String data = write_xml(v, indent);
+			return stream->write(data.data(), data.size());
+        }
+    }
+}

--- a/Modules/Luna/VariantUtils/XML.hpp
+++ b/Modules/Luna/VariantUtils/XML.hpp
@@ -19,21 +19,18 @@ namespace Luna
 {
 	namespace VariantUtils
 	{
+        LUNA_VARIANT_UTILS_API Variant new_xml_element(const Name& name);
+		LUNA_VARIANT_UTILS_API Name get_xml_name(const Variant& xml_element);
+		LUNA_VARIANT_UTILS_API void set_xml_name(Variant& xml_element, const Name& name);
+		LUNA_VARIANT_UTILS_API const Variant& get_xml_attributes(const Variant& xml_element);
+		LUNA_VARIANT_UTILS_API Variant& get_xml_attributes(Variant& xml_element);
+		LUNA_VARIANT_UTILS_API const Variant& get_xml_content(const Variant& xml_element);
+		LUNA_VARIANT_UTILS_API Variant& get_xml_content(Variant& xml_element);
+
 		//! @brief Reads one XML string.
-		LUNA_VARIANT_UTILS_API R<Variant> read_xml(const c8* src, usize src_size = USIZE_MAX);
-
+		LUNA_VARIANT_UTILS_API R<Variant> read_xml(const void* src, usize src_size = USIZE_MAX);
 		LUNA_VARIANT_UTILS_API R<Variant> read_xml(IStream* stream);
-
 		LUNA_VARIANT_UTILS_API String write_xml(const Variant& v, bool indent = true);
-		
 		LUNA_VARIANT_UTILS_API RV write_xml(IStream* stream, const Variant& v, bool indent = true);
-
-        LUNA_VARIANT_UTILS_API Variant new_xml_document(const c8* version = "1.0", const c8* encoding = "UTF-8");
-
-
-        LUNA_VARIANT_UTILS_API const Name& get_xml_version(const Variant& xml_document);
-        LUNA_VARIANT_UTILS_API void set_xml_version(Variant& xml_document);
-
-        LUNA_VARIANT_UTILS_API Name& get_xml_name(Variant& xml_node);
 	}
 }

--- a/Modules/Luna/VariantUtils/XML.hpp
+++ b/Modules/Luna/VariantUtils/XML.hpp
@@ -1,0 +1,39 @@
+/*!
+* This file is a portion of Luna SDK.
+* For conditions of distribution and use, see the disclaimer
+* and license in LICENSE.txt
+* 
+* @file XML.hpp
+* @author JXMaster
+* @date 2023/10/11
+*/
+#pragma once
+#include <Luna/Runtime/Variant.hpp>
+#include <Luna/Runtime/Stream.hpp>
+
+#ifndef LUNA_VARIANT_UTILS_API
+#define LUNA_VARIANT_UTILS_API
+#endif
+
+namespace Luna
+{
+	namespace VariantUtils
+	{
+		//! @brief Reads one XML string.
+		LUNA_VARIANT_UTILS_API R<Variant> read_xml(const c8* src, usize src_size = USIZE_MAX);
+
+		LUNA_VARIANT_UTILS_API R<Variant> read_xml(IStream* stream);
+
+		LUNA_VARIANT_UTILS_API String write_xml(const Variant& v, bool indent = true);
+		
+		LUNA_VARIANT_UTILS_API RV write_xml(IStream* stream, const Variant& v, bool indent = true);
+
+        LUNA_VARIANT_UTILS_API Variant new_xml_document(const c8* version = "1.0", const c8* encoding = "UTF-8");
+
+
+        LUNA_VARIANT_UTILS_API const Name& get_xml_version(const Variant& xml_document);
+        LUNA_VARIANT_UTILS_API void set_xml_version(Variant& xml_document);
+
+        LUNA_VARIANT_UTILS_API Name& get_xml_name(Variant& xml_node);
+	}
+}

--- a/Tests/RuntimeTest/Source/TestCommon.hpp
+++ b/Tests/RuntimeTest/Source/TestCommon.hpp
@@ -32,6 +32,7 @@ namespace Luna
 	void array_test();
 	void invoke_test();
 	void function_test();
+	void unicode_test();
 
 	// STL test framework modified from EASTL.
 

--- a/Tests/RuntimeTest/Source/TestMain.cpp
+++ b/Tests/RuntimeTest/Source/TestMain.cpp
@@ -32,6 +32,7 @@ void run()
 	serialize_test();
 	invoke_test();
 	function_test();
+	unicode_test();
 }
 
 int main()

--- a/Tests/RuntimeTest/Source/UnicodeTest.cpp
+++ b/Tests/RuntimeTest/Source/UnicodeTest.cpp
@@ -16,7 +16,7 @@ namespace Luna
     {
         // UTF-8
         {
-            c8 ch_utf8[] = {0xE4, 0xB8, 0xAD};
+            c8 ch_utf8[] = {(c8)0xE4, (c8)0xB8, (c8)0xAD};
             usize ch_len = utf8_charlen(ch_utf8);
             lucheck(ch_len == 3);
             c32 ch = utf8_decode_char(ch_utf8);

--- a/Tests/RuntimeTest/Source/UnicodeTest.cpp
+++ b/Tests/RuntimeTest/Source/UnicodeTest.cpp
@@ -25,9 +25,9 @@ namespace Luna
             lucheck(ch_len == 3);
             c8 ch_utf8_out[3] = {};
             utf8_encode_char(ch_utf8_out, ch);
-            lucheck(ch_utf8_out[0] == 0xE4);
-            lucheck(ch_utf8_out[1] == 0xB8);
-            lucheck(ch_utf8_out[2] == 0xAD);
+            lucheck((u8)ch_utf8_out[0] == 0xE4);
+            lucheck((u8)ch_utf8_out[1] == 0xB8);
+            lucheck((u8)ch_utf8_out[2] == 0xAD);
         }
         // UTF-16: system-default endian.
         {
@@ -53,10 +53,6 @@ namespace Luna
             utf16_encode_char(ch_utf16_2_out, ch);
             lucheck(ch_utf16_2_out[0] == 0xD802);
             lucheck(ch_utf16_2_out[1] == 0xDE6F);
-        }
-        // UTF-16: LE
-        {
-            
         }
     }
 }

--- a/Tests/RuntimeTest/Source/UnicodeTest.cpp
+++ b/Tests/RuntimeTest/Source/UnicodeTest.cpp
@@ -1,0 +1,62 @@
+/*!
+* This file is a portion of Luna SDK.
+* For conditions of distribution and use, see the disclaimer
+* and license in LICENSE.txt
+* 
+* @file UnicodeTest.cpp
+* @author JXMaster
+* @date 2023/10/11
+*/
+#include "TestCommon.hpp"
+#include <Luna/Runtime/Unicode.hpp>
+
+namespace Luna
+{
+    void unicode_test()
+    {
+        // UTF-8
+        {
+            c8 ch_utf8[] = {0xE4, 0xB8, 0xAD};
+            usize ch_len = utf8_charlen(ch_utf8);
+            lucheck(ch_len == 3);
+            c32 ch = utf8_decode_char(ch_utf8);
+            lucheck(ch == 0x4E2D);
+            ch_len = utf8_charspan(ch);
+            lucheck(ch_len == 3);
+            c8 ch_utf8_out[3] = {};
+            utf8_encode_char(ch_utf8_out, ch);
+            lucheck(ch_utf8_out[0] == 0xE4);
+            lucheck(ch_utf8_out[1] == 0xB8);
+            lucheck(ch_utf8_out[2] == 0xAD);
+        }
+        // UTF-16: system-default endian.
+        {
+            c16 ch_utf16[] = { 0x4E2D };
+            usize ch_len = utf16_charlen(ch_utf16);
+            lucheck(ch_len == 1);
+            c32 ch = utf16_decode_char(ch_utf16);
+            lucheck(ch == 0x4E2D);
+            ch_len = utf16_charspan(ch);
+            lucheck(ch_len == 1);
+            c16 ch_utf16_out[1];
+            utf16_encode_char(ch_utf16_out, ch);
+            lucheck(ch_utf16_out[0] == 0x4E2D);
+            // 4-bytes character.
+            c16 ch_utf16_2[] = {0xD802, 0xDE6F};
+            ch_len = utf16_charlen(ch_utf16_2);
+            lucheck(ch_len == 2);
+            ch = utf16_decode_char(ch_utf16_2);
+            lucheck(ch == 0x10A6F);
+            ch_len = utf16_charspan(ch);
+            lucheck(ch_len == 2);
+            c16 ch_utf16_2_out[2];
+            utf16_encode_char(ch_utf16_2_out, ch);
+            lucheck(ch_utf16_2_out[0] == 0xD802);
+            lucheck(ch_utf16_2_out[1] == 0xDE6F);
+        }
+        // UTF-16: LE
+        {
+            
+        }
+    }
+}

--- a/Tests/VariantUtilsTest/Source/Main.cpp
+++ b/Tests/VariantUtilsTest/Source/Main.cpp
@@ -9,13 +9,16 @@
 */
 #include "TestCommon.hpp"
 #include <Luna/Runtime/Runtime.hpp>
+#include <Luna/Runtime/Module.hpp>
 using namespace Luna;
 
 int main()
 {
     Luna::init();
+    lupanic_if_failed(init_modules());
     json_test();
     diff_test();
+    xml_test();
     Luna::close();
     return 0;
 }

--- a/Tests/VariantUtilsTest/Source/TestCommon.hpp
+++ b/Tests/VariantUtilsTest/Source/TestCommon.hpp
@@ -12,4 +12,5 @@ namespace Luna
 {
     void json_test();
     void diff_test();
+    void xml_test();
 }

--- a/Tests/VariantUtilsTest/Source/XMLTest.cpp
+++ b/Tests/VariantUtilsTest/Source/XMLTest.cpp
@@ -1,0 +1,48 @@
+/*!
+* This file is a portion of Luna SDK.
+* For conditions of distribution and use, see the disclaimer
+* and license in LICENSE.txt
+* 
+* @file XMLTest.cpp
+* @author JXMaster
+* @date 2021/8/3
+*/
+#include "TestCommon.hpp"
+#include <Luna/VariantUtils/XML.hpp>
+
+namespace Luna
+{
+    void xml_test()
+    {
+        const c8* src = R"(
+<?xml version="1.0" encoding="UTF-8"?>
+<bookstore>
+    <book category="COOKING">
+        <title lang="en">Everyday Italian</title>
+        <author>Giada De Laurentiis</author>
+        <year>2005</year>
+        <price>30.00</price>
+    </book>
+    <book category="CHILDREN">
+        <title lang="en">Harry Potter</title>
+        <author>J K. Rowling</author>
+        <year>2005</year>
+        <price>29.99</price>
+    </book>
+    <book category="WEB">
+        <title lang="en">Learning XML</title>
+        <author>Erik T. Ray</author>
+        <year>2003</year>
+        <price>39.95</price>
+    </book>
+</bookstore>
+        )";
+        R<Variant> v = VariantUtils::read_xml(src);
+		luassert_always(succeeded(v));
+        String s = VariantUtils::write_xml(v.get());
+        printf("%s", s.c_str());
+		R<Variant> v2 = VariantUtils::read_xml(s.c_str());
+		luassert_always(succeeded(v2));
+		luassert_always(v.get() == v2.get());
+    }
+}


### PR DESCRIPTION
This merge adds XML serialization/deserialization support for variant utility library.
Every XML element is represented as one `Variant` object with `VariantType::object` type, which has two properties:
1. `attributes`: stores attributes of the element. This is a object-typed variant, and every attribute is indexed by its name.
2. `content`: stores contents of the element. This is a array-typed variant, every member of this variant is either a string (for character data) or another XML element object, which is the child of the XML element.