### PR TITLE
Add function call stack dumping APIs to Runtime

### DIFF
--- a/Modules/Luna/Runtime/Debug.hpp
+++ b/Modules/Luna/Runtime/Debug.hpp
@@ -1,0 +1,49 @@
+/*!
+* This file is a portion of Luna SDK.
+* For conditions of distribution and use, see the disclaimer
+* and license in LICENSE.txt
+* 
+* @file Debug.hpp
+* @author JXMaster
+* @date 2023/11/24
+*/
+#pragma once
+#include "Base.hpp"
+#include "Span.hpp"
+#include "Name.hpp"
+
+#ifndef LUNA_RUNTIME_API
+#define LUNA_RUNTIME_API
+#endif
+namespace Luna
+{
+    //! @addtogroup Runtime
+    //! @{
+    //! @defgroup RuntimeDebug Debugging
+    //! @}
+
+    //! @addtogroup RuntimeDebug
+    //! @{
+    
+    //! @brief Captures function call stack information of the current thread.
+    //! @param[out] frames One buffer that receives captured frames. Every frame is represented by 
+    //! one opaque handle in the buffer.
+    //! @return Returns the number of captured frames written to `frames`.
+    LUNA_RUNTIME_API u32 stack_backtrace(Span<opaque_t> frames);
+
+    //! @brief Gets symbolic names for frames returned by @ref stack_backtrace.
+    //! @param[in] frames One buffer that contains frames to query.
+    //! @return Returns one array of strings that store symbolic names for frames. Strings are stored in 
+    //! the same order as `frames`. If the symbolic name of one frame is not found, `nullptr` will be written.
+    //! @par Valid Usage
+    //! 1. All frames in `frames` must be valid frames returned by @ref stack_backtrace. In particular, if the return
+    //! value of @ref stack_backtrace is smaller than the size of the frame buffer passed to @ref stack_backtrace, only 
+    //! valid frames, not the whole buffer, shall be specified in this call.
+    LUNA_RUNTIME_API const c8** stack_backtrace_symbols(Span<const opaque_t> frames);
+
+    //! Frees symbols returned by @ref stack_backtrace_symbols.
+    //! @param[in] symbols The symbol array returned by @ref stack_backtrace_symbols.
+    LUNA_RUNTIME_API void free_backtrace_symbols(const c8** symbols);
+
+    //! @}
+}

--- a/Modules/Luna/Runtime/Source/Assert.cpp
+++ b/Modules/Luna/Runtime/Source/Assert.cpp
@@ -11,11 +11,24 @@
 #define LUNA_RUNTIME_API LUNA_EXPORT
 #include "OS.hpp"
 #include "../Assert.hpp"
+#include "../Log.hpp"
+#include "../Debug.hpp"
 
 namespace Luna
 {
 	LUNA_RUNTIME_API void assert_fail(const c8* msg, const c8* file, u32 line)
 	{
+		log(LogVerbosity::fatal_error, nullptr, "Assertion Failed: %s FILE: %s, LINE: %d", msg, file, line);
+		void* stack_frames[256];
+		u32 num_frames = stack_backtrace({stack_frames, 256});
+		const c8** symbols = stack_backtrace_symbols({stack_frames, num_frames});
+		log(LogVerbosity::fatal_error, nullptr, "Stack trace:");
+		for(u32 i = 0; i < num_frames; ++i)
+		{
+			if(symbols[i]) log(LogVerbosity::fatal_error, nullptr, "%s", symbols[i]);
+			else log(LogVerbosity::fatal_error, nullptr, "[Unnamed function]");
+		}
+		free_backtrace_symbols(symbols);
 		OS::assert_fail(msg, file, line);
 	}
 	LUNA_RUNTIME_API void debug_break()

--- a/Modules/Luna/Runtime/Source/Debug.cpp
+++ b/Modules/Luna/Runtime/Source/Debug.cpp
@@ -1,0 +1,29 @@
+/*!
+* This file is a portion of Luna SDK.
+* For conditions of distribution and use, see the disclaimer
+* and license in LICENSE.txt
+* 
+* @file Debug.cpp
+* @author JXMaster
+* @date 2023/11/24
+*/
+#include "../PlatformDefines.hpp"
+#define LUNA_RUNTIME_API LUNA_EXPORT
+#include "../Debug.hpp"
+#include "OS.hpp"
+
+namespace Luna
+{
+    LUNA_RUNTIME_API u32 stack_backtrace(Span<opaque_t> frames)
+    {
+        return OS::stack_backtrace(frames);
+    }
+    LUNA_RUNTIME_API const c8** stack_backtrace_symbols(Span<const opaque_t> frames)
+    {
+        return OS::stack_backtrace_symbols(frames);
+    }
+    LUNA_RUNTIME_API void free_backtrace_symbols(const c8** symbols)
+    {
+        OS::free_backtrace_symbols(symbols);
+    }
+}

--- a/Modules/Luna/Runtime/Source/Log.cpp
+++ b/Modules/Luna/Runtime/Source/Log.cpp
@@ -132,6 +132,7 @@ namespace Luna
 		}
 		c8* use_buf = abuf ? abuf : buf;
 		MutexGuard guard(g_log_mutex);
+		if(!tag) tag = "";
 		g_log_callbacks(verbosity, tag, strlen(tag), use_buf, len);
 		guard.unlock();
 		if (abuf) memfree(abuf);

--- a/Modules/Luna/Runtime/Source/OS.hpp
+++ b/Modules/Luna/Runtime/Source/OS.hpp
@@ -487,6 +487,26 @@ namespace Luna
 		//! 
 		//! This function must be thread-safe.
 		RV std_output(const c8* buffer, usize size, usize* write_bytes);
+
+		//! @brief Captures function call stack information of the current thread.
+		//! @param[out] frames One buffer that receives captured frames. Every frame is represented by 
+		//! one opaque handle in the buffer.
+		//! @return Returns the number of captured frames written to `frames`.
+		u32 stack_backtrace(Span<opaque_t> frames);
+
+		//! @brief Gets symbolic names for frames returned by @ref stack_backtrace.
+		//! @param[in] frames One buffer that contains frames to query.
+		//! @return Returns one array of strings that store symbolic names for frames. Strings are stored in 
+		//! the same order as `frames`. If the symbolic name of one frame is not found, `nullptr` will be written.
+		//! @par Valid Usage
+		//! 1. All frames in `frames` must be valid frames returned by @ref stack_backtrace. In particular, if the return
+		//! value of @ref stack_backtrace is smaller than the size of the frame buffer passed to @ref stack_backtrace, only 
+		//! valid frames, not the whole buffer, shall be specified in this call.
+		const c8** stack_backtrace_symbols(Span<const opaque_t> frames);
+
+		//! Frees symbols returned by @ref stack_backtrace_symbols.
+    	//! @param[in] symbols The symbol array returned by @ref stack_backtrace_symbols.
+		void free_backtrace_symbols(const c8** symbols);
 	}
 
 	//! The allocator that allocates memory from OS directly.

--- a/Modules/Luna/Runtime/Source/Platform/POSIX/Assert.cpp
+++ b/Modules/Luna/Runtime/Source/Platform/POSIX/Assert.cpp
@@ -7,10 +7,6 @@
 * @author JXMaster
 * @date 2020/9/22
  */
-#include <Luna/Runtime/PlatformDefines.hpp>
-
-#ifdef LUNA_PLATFORM_POSIX
-
 #include "../../OS.hpp"
 #include <Luna/Runtime/Unicode.hpp>
 #include <assert.h>
@@ -21,7 +17,7 @@ namespace Luna
     {
         void assert_fail(const c8* msg, const c8* file, u32 line)
         {
-            printf ("%s:%d: failed assertion `%s'\n", file, line, msg);
+            printf ("Assertion Failed: %s FILE: %s, LINE: %d", msg, file, line);
             abort();
         }
 
@@ -34,5 +30,3 @@ namespace Luna
 
     }
 }
-
-#endif

--- a/Modules/Luna/Runtime/Source/Platform/POSIX/AtomicImpl.hpp
+++ b/Modules/Luna/Runtime/Source/Platform/POSIX/AtomicImpl.hpp
@@ -10,8 +10,6 @@
 #pragma once
 #include "../../../Base.hpp"
 
-#ifdef LUNA_PLATFORM_POSIX
-
 namespace Luna
 {
 	inline i32 atom_inc_i32(i32 volatile* v)
@@ -137,4 +135,3 @@ namespace Luna
 	}
 
 }
-#endif

--- a/Modules/Luna/Runtime/Source/Platform/POSIX/Debug.cpp
+++ b/Modules/Luna/Runtime/Source/Platform/POSIX/Debug.cpp
@@ -24,7 +24,7 @@ namespace Luna
         }
         void free_backtrace_symbols(const c8** symbols)
         {
-            free(handle);
+            free(symbols);
         }
     }
 }

--- a/Modules/Luna/Runtime/Source/Platform/POSIX/Debug.cpp
+++ b/Modules/Luna/Runtime/Source/Platform/POSIX/Debug.cpp
@@ -1,0 +1,30 @@
+/*!
+* This file is a portion of Luna SDK.
+* For conditions of distribution and use, see the disclaimer
+* and license in LICENSE.txt
+* 
+* @file Debug.cpp
+* @author JXMaster
+* @date 2023/11/24
+ */
+#include "../../OS.hpp"
+#include <execinfo.h>
+
+namespace Luna
+{
+    namespace OS
+    {
+        u32 stack_backtrace(Span<opaque_t> frames)
+        {
+            return (u32)backtrace(frames.data(), (int)frames.size());
+        }
+        const c8** stack_backtrace_symbols(Span<const opaque_t> frames)
+        {
+            return (const c8**)backtrace_symbols(frames.data(), (int)frames.size());
+        }
+        void free_backtrace_symbols(const c8** symbols)
+        {
+            free(handle);
+        }
+    }
+}

--- a/Modules/Luna/Runtime/Source/Platform/POSIX/Errno.hpp
+++ b/Modules/Luna/Runtime/Source/Platform/POSIX/Errno.hpp
@@ -8,9 +8,6 @@
 * @date 2020/9/22
  */
 #pragma once
-#include <Luna/Runtime/PlatformDefines.hpp>
-#ifdef LUNA_PLATFORM_POSIX
-
 #include <errno.h>
 
 namespace Luna
@@ -101,5 +98,3 @@ namespace Luna
         }
     }
 }
-
-#endif

--- a/Modules/Luna/Runtime/Source/Platform/POSIX/File.cpp
+++ b/Modules/Luna/Runtime/Source/Platform/POSIX/File.cpp
@@ -7,9 +7,6 @@
 * @author JXMaster
 * @date 2020/9/27
 */
-#include <Luna/Runtime/PlatformDefines.hpp>
-#ifdef LUNA_PLATFORM_POSIX
-
 #include "../../OS.hpp"
 #include <Luna/Runtime/Unicode.hpp>
 #include <Luna/Runtime/Algorithm.hpp>
@@ -814,4 +811,3 @@ namespace Luna
 		}
     }
 }
-#endif

--- a/Modules/Luna/Runtime/Source/Platform/POSIX/Log.cpp
+++ b/Modules/Luna/Runtime/Source/Platform/POSIX/Log.cpp
@@ -7,9 +7,6 @@
 * @author JXMaster
 * @date 2023/9/7
 */
-#include <Luna/Runtime/PlatformDefines.hpp>
-
-#ifdef LUNA_PLATFORM_POSIX
 #include "../../OS.hpp"
 #include <unistd.h>
 
@@ -57,5 +54,3 @@ namespace Luna
 		}
 	}
 }
-
-#endif

--- a/Modules/Luna/Runtime/Source/Platform/POSIX/Memory.cpp
+++ b/Modules/Luna/Runtime/Source/Platform/POSIX/Memory.cpp
@@ -7,10 +7,6 @@
 * @author JXMaster
 * @date 2020/9/22
  */
-#include <Luna/Runtime/PlatformDefines.hpp>
-
-#ifdef LUNA_PLATFORM_POSIX
-
 #include "../../OS.hpp"
 #include <sys/mman.h>
 #include "Errno.hpp"
@@ -74,5 +70,3 @@ namespace Luna
         }
     }
 }
-
-#endif

--- a/Modules/Luna/Runtime/Source/Platform/POSIX/OS.cpp
+++ b/Modules/Luna/Runtime/Source/Platform/POSIX/OS.cpp
@@ -7,10 +7,6 @@
 * @author JXMaster
 * @date 2021/4/25
  */
-#include <Luna/Runtime/PlatformDefines.hpp>
-
-#ifdef LUNA_PLATFORM_POSIX
-
 #include "../../OS.hpp"
 #include <sys/types.h>
 #ifdef LUNA_PLATFORM_MACOS
@@ -61,5 +57,3 @@ namespace Luna
 		}
     }
 }
-
-#endif

--- a/Modules/Luna/Runtime/Source/Platform/POSIX/StdIO.cpp
+++ b/Modules/Luna/Runtime/Source/Platform/POSIX/StdIO.cpp
@@ -7,9 +7,6 @@
 * @author JXMaster
 * @date 2023/2/28
 */
-#include <Luna/Runtime/PlatformDefines.hpp>
-
-#ifdef LUNA_PLATFORM_POSIX
 #include "../../OS.hpp"
 #include "../../../Unicode.hpp"
 #include <cstdio>
@@ -115,5 +112,3 @@ namespace Luna
         }
     }
 }
-
-#endif

--- a/Modules/Luna/Runtime/Source/Platform/POSIX/Sync.cpp
+++ b/Modules/Luna/Runtime/Source/Platform/POSIX/Sync.cpp
@@ -7,10 +7,6 @@
 * @author JXMaster
 * @date 2020/9/22
  */
-#include <Luna/Runtime/PlatformDefines.hpp>
-
-#ifdef LUNA_PLATFORM_POSIX
-
 #include "../../OS.hpp"
 #include <pthread.h>
 #include <sys/time.h>
@@ -275,5 +271,3 @@ namespace Luna
         }
     }
 }
-
-#endif

--- a/Modules/Luna/Runtime/Source/Platform/POSIX/Thread.cpp
+++ b/Modules/Luna/Runtime/Source/Platform/POSIX/Thread.cpp
@@ -7,10 +7,6 @@
 * @author JXMaster
 * @date 2020/9/28
 */
-#include <Luna/Runtime/PlatformDefines.hpp>
-
-#ifdef LUNA_PLATFORM_POSIX
-
 #include "../../OS.hpp"
 
 #include <unistd.h>
@@ -215,5 +211,3 @@ void* tls_get(opaque_t handle)
 }
 }
 }
-
-#endif

--- a/Modules/Luna/Runtime/Source/Platform/POSIX/Time.cpp
+++ b/Modules/Luna/Runtime/Source/Platform/POSIX/Time.cpp
@@ -7,10 +7,6 @@
 * @author JXMaster
 * @date 2020/9/23
 */
-#include <Luna/Runtime/PlatformDefines.hpp>
-
-#ifdef LUNA_PLATFORM_POSIX
-
 #include "../../OS.hpp"
 #include <stdint.h>
 #include <time.h>
@@ -110,5 +106,3 @@ namespace Luna
         }
     }
 }
-
-#endif

--- a/Modules/Luna/Runtime/Source/Platform/Windows/Assert.cpp
+++ b/Modules/Luna/Runtime/Source/Platform/Windows/Assert.cpp
@@ -7,10 +7,6 @@
 * @author JXMaster
 * @date 2018/10/26
  */
-#include <Luna/Runtime/PlatformDefines.hpp>
-
-#ifdef LUNA_PLATFORM_WINDOWS
-
 #include "../../OS.hpp"
 #include <Luna/Runtime/Unicode.hpp>
 #include <assert.h>
@@ -44,5 +40,3 @@ namespace Luna
     }
 
 }
-
-#endif

--- a/Modules/Luna/Runtime/Source/Platform/Windows/AtomicImpl.hpp
+++ b/Modules/Luna/Runtime/Source/Platform/Windows/AtomicImpl.hpp
@@ -12,7 +12,6 @@
 
 #include <atomic>
 
-#ifdef LUNA_PLATFORM_WINDOWS
 #include "../../../Platform/Windows/MiniWin.hpp"
 
 namespace Luna
@@ -163,4 +162,3 @@ namespace Luna
 #endif
 
 }
-#endif

--- a/Modules/Luna/Runtime/Source/Platform/Windows/Debug.cpp
+++ b/Modules/Luna/Runtime/Source/Platform/Windows/Debug.cpp
@@ -1,0 +1,109 @@
+/*!
+* This file is a portion of Luna SDK.
+* For conditions of distribution and use, see the disclaimer
+* and license in LICENSE.txt
+* 
+* @file Debug.cpp
+* @author JXMaster
+* @date 2023/11/24
+ */
+#include "../../../Platform/Windows/MiniWin.hpp"
+#include "../../OS.hpp"
+#include "../../../SpinLock.hpp"
+#include <DbgHelp.h>
+
+#pragma comment(lib, "DbgHelp.lib")
+
+namespace Luna
+{
+    namespace OS
+    {
+        HANDLE g_debug_process;
+        SpinLock g_stack_backtrace_lock;
+        void debug_init()
+        {
+            g_debug_process = GetCurrentProcess();
+            SymInitialize(g_debug_process, NULL, TRUE);
+        }
+        void debug_close()
+        {
+            SymCleanup(g_debug_process);
+        }
+        u32 stack_backtrace(Span<opaque_t> frames)
+        {
+            LockGuard guard(g_stack_backtrace_lock);
+            return CaptureStackBackTrace(3, (u32)frames.size(), frames.data(), NULL);
+        }
+        const c8** stack_backtrace_symbols(Span<const opaque_t> frames)
+        {
+            LockGuard guard(g_stack_backtrace_lock);
+            usize ret_size = sizeof(const c8*) * frames.size();
+            for(usize i = 0; i < frames.size(); ++i)
+            {
+                DWORD64 address = (DWORD64)(frames[i]);
+                c8 buffer[sizeof(SYMBOL_INFO) + MAX_SYM_NAME * sizeof(TCHAR)];
+                PSYMBOL_INFO symbol = (PSYMBOL_INFO)buffer;
+                memzero(symbol);
+                symbol->SizeOfStruct = sizeof(SYMBOL_INFO);
+                symbol->MaxNameLen = MAX_SYM_NAME;
+                DWORD64 displacement = 0;
+                if (SymFromAddr(g_debug_process, address, &displacement, symbol))
+                {
+                    DWORD line_displacement = 0;
+                    IMAGEHLP_LINE64 line_info;
+                    line_info.SizeOfStruct = sizeof(IMAGEHLP_LINE64);
+                    int len;
+                    if(SymGetLineFromAddr64(g_debug_process, address, &line_displacement, &line_info))
+                    {
+                        len = snprintf(nullptr, 0, "0x%016llx %s [%s:%u]", (u64)symbol->Address, symbol->Name, line_info.FileName, line_info.LineNumber);
+                    }
+                    else
+                    {
+                        len = snprintf(nullptr, 0, "0x%016llx %s", (u64)symbol->Address, symbol->Name);
+                    }
+                    ret_size += (len + 1);
+                }
+            }
+            c8** ret = (c8**)memalloc(ret_size);
+            c8* str = (c8*)(ret + frames.size());
+            usize str_size = ret_size - sizeof(const c8*) * frames.size();
+            for(usize i = 0; i < frames.size(); ++i)
+            {
+                DWORD64 address = (DWORD64)(frames[i]);
+                c8 buffer[sizeof(SYMBOL_INFO) + MAX_SYM_NAME * sizeof(TCHAR)];
+                PSYMBOL_INFO symbol = (PSYMBOL_INFO)buffer;
+                memzero(symbol);
+                symbol->SizeOfStruct = sizeof(SYMBOL_INFO);
+                symbol->MaxNameLen = MAX_SYM_NAME;
+                DWORD64 displacement = 0;
+                if (SymFromAddr(g_debug_process, address, &displacement, symbol))
+                {
+                    DWORD line_displacement = 0;
+                    IMAGEHLP_LINE64 line_info;
+                    line_info.SizeOfStruct = sizeof(IMAGEHLP_LINE64);
+                    int len;
+                    if(SymGetLineFromAddr64(g_debug_process, address, &line_displacement, &line_info))
+                    {
+                        len = snprintf(str, str_size, "0x%016llx %s [%s:%u]", (u64)symbol->Address, symbol->Name, line_info.FileName, line_info.LineNumber);
+                    }
+                    else
+                    {
+                        len = snprintf(str, str_size, "0x%016llx %s", (u64)symbol->Address, symbol->Name);
+                    }
+                    ret[i] = str;
+                    str += (len + 1);
+                    str_size -= (len + 1);
+                }
+                else
+                {
+                    ret[i] = nullptr;
+                }
+            }
+            return (const c8**)ret;
+        }
+        void free_backtrace_symbols(const c8** symbols)
+        {
+            memfree(symbols);
+        }
+    }
+}

--- a/Modules/Luna/Runtime/Source/Platform/Windows/ErrCode.hpp
+++ b/Modules/Luna/Runtime/Source/Platform/Windows/ErrCode.hpp
@@ -7,9 +7,6 @@
 * @author JXMaster
 * @date 2023/3/26
 */
-#include <Luna/Runtime/PlatformDefines.hpp>
-#ifdef LUNA_PLATFORM_WINDOWS
-
 #include "../../../Platform/Windows/MiniWin.hpp"
 #include "../../../Result.hpp"
 
@@ -37,5 +34,3 @@ namespace Luna
         }
     }
 }
-
-#endif

--- a/Modules/Luna/Runtime/Source/Platform/Windows/File.cpp
+++ b/Modules/Luna/Runtime/Source/Platform/Windows/File.cpp
@@ -7,11 +7,6 @@
 * @author JXMaster
 * @date 2019/9/29
 */
-#include <Luna/Runtime/PlatformDefines.hpp>
-#ifdef LUNA_PLATFORM_WINDOWS
-
-#define LUNA_RUNTIME_API LUNA_EXPORT
-
 #include "../../../Platform/Windows/MiniWin.hpp"
 #include <io.h>
 #include <Luna/Runtime/Unicode.hpp>
@@ -848,5 +843,3 @@ namespace Luna
 
 
 }
-
-#endif

--- a/Modules/Luna/Runtime/Source/Platform/Windows/Log.cpp
+++ b/Modules/Luna/Runtime/Source/Platform/Windows/Log.cpp
@@ -7,9 +7,6 @@
 * @author JXMaster
 * @date 2023/9/7
 */
-#include <Luna/Runtime/PlatformDefines.hpp>
-
-#ifdef LUNA_PLATFORM_WINDOWS
 #include "../../OS.hpp"
 #include "../../../Platform/Windows/MiniWin.hpp"
 #include "../../../Unicode.hpp"
@@ -79,5 +76,3 @@ namespace Luna
 		}
 	}
 }
-
-#endif

--- a/Modules/Luna/Runtime/Source/Platform/Windows/Memory.cpp
+++ b/Modules/Luna/Runtime/Source/Platform/Windows/Memory.cpp
@@ -7,10 +7,6 @@
 * @author JXMaster
 * @date 2020/7/28
  */
-#include <Luna/Runtime/PlatformDefines.hpp>
-
-#ifdef LUNA_PLATFORM_WINDOWS
-
 #include <Luna/Runtime/Assert.hpp>
 #include "../../../Platform/Windows/MiniWin.hpp"
 #include "../../OS.hpp"
@@ -47,5 +43,3 @@ namespace Luna
 		}
 	}
 }
-
-#endif

--- a/Modules/Luna/Runtime/Source/Platform/Windows/Mutex.cpp
+++ b/Modules/Luna/Runtime/Source/Platform/Windows/Mutex.cpp
@@ -7,9 +7,6 @@
 * @author JXMaster
 * @date 2022/3/2
 */
-#include <Luna/Runtime/PlatformDefines.hpp>
-
-#ifdef LUNA_PLATFORM_WINDOWS
 #include "../../OS.hpp"
 #include "../../../Platform/Windows/MiniWin.hpp"
 
@@ -46,5 +43,3 @@ namespace Luna
 		}
 	}
 }
-
-#endif

--- a/Modules/Luna/Runtime/Source/Platform/Windows/OS.cpp
+++ b/Modules/Luna/Runtime/Source/Platform/Windows/OS.cpp
@@ -7,9 +7,6 @@
 * @author JXMaster
 * @date 2020/12/9
  */
-#include <Luna/Runtime/PlatformDefines.hpp>
-
-#ifdef LUNA_PLATFORM_WINDOWS
 #include "../../OS.hpp"
 #include "../../../Platform/Windows/MiniWin.hpp"
 
@@ -23,9 +20,12 @@ namespace Luna
 		void file_init();
 		void std_io_init();
 		void std_io_close();
+		void debug_init();
+		void debug_close();
 
 		void init()
 		{
+			debug_init();
 			time_init();
 			thread_init();
 			file_init();
@@ -36,6 +36,7 @@ namespace Luna
 		{
 			std_io_close();
 			thread_close();
+			debug_close();
 		}
 
 		u32 get_num_processors()
@@ -47,5 +48,3 @@ namespace Luna
 		}
 	}
 }
-
-#endif

--- a/Modules/Luna/Runtime/Source/Platform/Windows/ReadWriteLock.cpp
+++ b/Modules/Luna/Runtime/Source/Platform/Windows/ReadWriteLock.cpp
@@ -7,9 +7,6 @@
 * @author JXMaster
 * @date 2022/8/29
 */
-#include <Luna/Runtime/PlatformDefines.hpp>
-
-#ifdef LUNA_PLATFORM_WINDOWS
 #include "../../OS.hpp"
 #include "../../../Platform/Windows/MiniWin.hpp"
 
@@ -53,5 +50,3 @@ namespace Luna
 		}
 	}
 }
-
-#endif

--- a/Modules/Luna/Runtime/Source/Platform/Windows/Semaphore.cpp
+++ b/Modules/Luna/Runtime/Source/Platform/Windows/Semaphore.cpp
@@ -7,11 +7,6 @@
 * @author JXMaster
 * @date 2022/3/10
 */
-#pragma once
-
-#include <Luna/Runtime/PlatformDefines.hpp>
-
-#ifdef LUNA_PLATFORM_WINDOWS
 #include "../../OS.hpp"
 #include "../../../Platform/Windows/MiniWin.hpp"
 
@@ -53,5 +48,3 @@ namespace Luna
 		}
 	}
 }
-
-#endif

--- a/Modules/Luna/Runtime/Source/Platform/Windows/Signal.cpp
+++ b/Modules/Luna/Runtime/Source/Platform/Windows/Signal.cpp
@@ -7,11 +7,6 @@
 * @author JXMaster
 * @date 2022/3/10
 */
-#pragma once
-
-#include <Luna/Runtime/PlatformDefines.hpp>
-
-#ifdef LUNA_PLATFORM_WINDOWS
 #include "../../OS.hpp"
 #include "../../../Platform/Windows/MiniWin.hpp"
 
@@ -114,5 +109,3 @@ namespace Luna
 		}
 	}
 }
-
-#endif

--- a/Modules/Luna/Runtime/Source/Platform/Windows/StdIO.cpp
+++ b/Modules/Luna/Runtime/Source/Platform/Windows/StdIO.cpp
@@ -7,9 +7,6 @@
 * @author JXMaster
 * @date 2023/2/28
 */
-#include <Luna/Runtime/PlatformDefines.hpp>
-
-#ifdef LUNA_PLATFORM_WINDOWS
 #include "../../OS.hpp"
 #include "../../../Platform/Windows/MiniWin.hpp"
 #include "../../../Unicode.hpp"
@@ -114,4 +111,3 @@ namespace Luna
         }
     }
 }
-#endif

--- a/Modules/Luna/Runtime/Source/Platform/Windows/Thread.cpp
+++ b/Modules/Luna/Runtime/Source/Platform/Windows/Thread.cpp
@@ -7,10 +7,6 @@
 * @author JXMaster
 * @date 2020/7/30
 */
-#include <Luna/Runtime/PlatformDefines.hpp>
-
-#ifdef LUNA_PLATFORM_WINDOWS
-
 #include "../../OS.hpp"
 #include "../../../Platform/Windows/MiniWin.hpp"
 #include <Luna/Runtime/HashMap.hpp>
@@ -208,5 +204,3 @@ namespace Luna
 		}
 	}
 }
-
-#endif

--- a/Modules/Luna/Runtime/Source/Platform/Windows/Time.cpp
+++ b/Modules/Luna/Runtime/Source/Platform/Windows/Time.cpp
@@ -7,10 +7,6 @@
 * @author JXMaster
 * @date 2020/8/16
 */
-#pragma once
-#include <Luna/Runtime/PlatformDefines.hpp>
-
-#ifdef LUNA_PLATFORM_WINDOWS
 #include "../../OS.hpp"
 #include "../../../Platform/Windows/MiniWin.hpp"
 
@@ -87,5 +83,3 @@ namespace Luna
 		}
 	}
 }
-
-#endif

--- a/Modules/Luna/Runtime/Source/Platform/Windows/Utils.hpp
+++ b/Modules/Luna/Runtime/Source/Platform/Windows/Utils.hpp
@@ -8,9 +8,6 @@
 * @date 2018/11/14
 */
 #pragma once
-#include <Luna/Runtime/PlatformDefines.hpp>
-
-#ifdef LUNA_PLATFORM_WINDOWS
 #include "../../../Platform/Windows/MiniWin.hpp"
 #include "../../../Unicode.hpp"
 #include "../../OS.hpp"
@@ -27,4 +24,3 @@ namespace Luna
 		}
 	}
 }
-#endif

--- a/Tests/RuntimeTest/Source/TestMain.cpp
+++ b/Tests/RuntimeTest/Source/TestMain.cpp
@@ -9,11 +9,12 @@
 */
 #include "TestCommon.hpp"
 #include <Luna/Runtime/Memory.hpp>
-
+#include <Luna/Runtime/Log.hpp>
 using namespace Luna;
 
 void run()
 {
+	set_log_to_platform_enabled(true);
 	auto handle = register_profiler_callback(memory_profiler_callback);
 	array_test();
 	vector_test();


### PR DESCRIPTION
This merge adds three new APIs to Runtime to  support dumping function call stacks in LunaSDK, such feature is useful when debugging program crashes and handling errors.