### PR TITLE
Fix the bug that causes properties in base type of one derived structure type not get serialized/deserialized.

### DIFF
--- a/Modules/Luna/Runtime/Reflection.hpp
+++ b/Modules/Luna/Runtime/Reflection.hpp
@@ -726,6 +726,16 @@ namespace Luna
     //! * `type` must specify one valid type object.
     LUNA_RUNTIME_API Span<const StructurePropertyDesc> get_struct_properties(typeinfo_t type);
 
+    //! Gets properties of the specified structure.
+    //! @param[in] type The type to query.
+    //! @param[out] out_properties Returns properties of the specified structure. Existing elements in the vector will not be modified.
+    //! If `type` is not a structure or generic structure instanced type, this vector is not changed.
+    //! @param[in] include_base_type Whether to query properties that belongs to the base type of this structure type if this structure type has
+    //! base type. If this is `false`, only properties that belongs to this type (not the base type) will be returned.
+    //! @par Valid Usage
+    //! * `type` must specify one valid type object.
+    LUNA_RUNTIME_API void get_struct_properties(typeinfo_t type, Vector<StructurePropertyDesc>& out_properties, bool include_base_type = true);
+    
     //! Gets the base type of the specified type.
     //! @param[in] type The type to query.
     //! @return Returns the base type of the specified type.

--- a/Modules/Luna/Runtime/Source/Serialization.cpp
+++ b/Modules/Luna/Runtime/Source/Serialization.cpp
@@ -21,7 +21,8 @@ namespace Luna
         Variant ret(VariantType::object);
         lutry
         {
-            auto properties = get_struct_properties(type);
+            Vector<StructurePropertyDesc> properties;
+            get_struct_properties(type, properties);
             for(auto& prop : properties)
             {
                 if (is_type_serializable(prop.type))
@@ -38,7 +39,8 @@ namespace Luna
     {
         lutry
         {
-            auto properties = get_struct_properties(type);
+            Vector<StructurePropertyDesc> properties;
+            get_struct_properties(type, properties);
             for(auto& prop : properties)
             {
                 auto& prop_data = data[prop.name];

--- a/Modules/Luna/Runtime/Source/TypeInfo.cpp
+++ b/Modules/Luna/Runtime/Source/TypeInfo.cpp
@@ -1140,6 +1140,34 @@ namespace Luna
         }
         return Span<const StructurePropertyDesc>();
     }
+    LUNA_RUNTIME_API void get_struct_properties(typeinfo_t type, Vector<StructurePropertyDesc>& out_properties, bool include_base_type)
+    {
+        TypeInfo* t = (TypeInfo*)type;
+        switch (t->kind)
+        {
+        case TypeKind::structure:
+        {
+            StructureTypeInfo* type = (StructureTypeInfo*)t;
+            if(include_base_type && type->base_type)
+            {
+                get_struct_properties(type->base_type, out_properties, true);
+            }
+            out_properties.insert(out_properties.end(), type->property_descs.begin(), type->property_descs.end());
+            break;
+        }
+        case TypeKind::generic_structure_instanced:
+        {
+            GenericStructureInstancedTypeInfo* type = (GenericStructureInstancedTypeInfo*)t;
+            if(include_base_type && type->base_type)
+            {
+                get_struct_properties(type->base_type, out_properties, true);
+            }
+            out_properties.insert(out_properties.end(), type->property_descs.begin(), type->property_descs.end());
+            break;
+        } 
+        default: break;
+        }
+    }
     LUNA_RUNTIME_API typeinfo_t get_base_type(typeinfo_t type)
     {
         TypeInfo* t = (TypeInfo*)type;


### PR DESCRIPTION
[Runtime]Adds one new `get_struct_properties` function that will return properties of base type for one structure type.
[Runtime]Fix the bug that causes properties in base type of one derived structure type not get serialized/deserialized.