### PR TITLE
Use new sparse hashing map to replace robinhood hashing

### DIFF
--- a/Modules/Luna/Runtime/HashMap.hpp
+++ b/Modules/Luna/Runtime/HashMap.hpp
@@ -217,6 +217,46 @@ namespace Luna
         {
             m_base.shrink_to_fit();
         }
+        //! Sorts elements using the specified comparison function.
+        //! @param[in] comp The comparison function object, which returns `true` if the first key-value pair should be ordered before the second key-value pair.
+        //! @remark This invalidates all iterators, references and pointers to elements.
+        template <typename _Compare>
+        void sort(_Compare comp)
+        {
+            m_base.sort(comp);
+        }
+        //! Sorts elements by key in non-descending order.
+        //! @remark This invalidates all iterators, references and pointers to elements.
+        void key_sort()
+        {
+            key_sort(less<key_type>());
+        }
+        //! Sorts elements by key using the specified comparison function.
+        //! @param[in] comp The comparison function object, which returns `true` if the first key should be ordered before the second key.
+        //! @remark This invalidates all iterators, references and pointers to elements.
+        template <typename _Compare>
+        void key_sort(_Compare comp)
+        {
+            m_base.sort([comp](const value_type& lhs, const value_type& rhs) {
+                return comp(lhs.first, rhs.first);
+            });
+        }
+        //! Sorts elements by value in non-descending order.
+        //! @remark This invalidates all iterators, references and pointers to elements.
+        void value_sort()
+        {
+            value_sort(less<mapped_type>());
+        }
+        //! Sorts elements by value using the specified comparison function.
+        //! @param[in] comp The comparison function object, which returns `true` if the first value should be ordered before the second value.
+        //! @remark This invalidates all iterators, references and pointers to elements.
+        template <typename _Compare>
+        void value_sort(_Compare comp)
+        {
+            m_base.sort([comp](const value_type& lhs, const value_type& rhs) {
+                return comp(lhs.second, rhs.second);
+            });
+        }
         //! Gets the hash function used by this map.
         //! @return Returns the hash function used by this map.
         hasher hash_function() const

--- a/Modules/Luna/Runtime/HashMap.hpp
+++ b/Modules/Luna/Runtime/HashMap.hpp
@@ -8,7 +8,7 @@
 * @date 2022/5/1
 */
 #pragma once
-#include "Impl/RobinHoodHashTable.hpp"
+#include "Impl/SparseHashTable.hpp"
 #include "TypeInfo.hpp"
 
 namespace Luna
@@ -16,14 +16,18 @@ namespace Luna
     //! @addtogroup RuntimeContainer
     //! @{
     
-    //! An container that contains key-value pairs with unique keys using open-addressing hashing algorithm.
-    //! @remark LunaSDK provides two kinds of hashing-based containers: open-addressing containers and closed-addressing containers.
-    //! The following containers are open-addressing containers, implemented using Robinhood hashing:
+    //! An container that contains key-value pairs with unique keys using sparse-array hashing algorithm.
+    //! @remark LunaSDK provides several kinds of hashing-based containers. The following containers store elements in sparse arrays and
+    //! use bucket chains to resolve hash collisions:
     //! 
     //! 1. @ref HashMap
     //! 2. @ref HashSet
+    //! The following containers use Robin Hood open-addressing hashing:
+    //!
+    //! 1. @ref RobinMap
+    //! 2. @ref RobinSet
     //! 3. @ref SelfIndexedHashmap
-    //! The following containers are closed-addressing containers, implemented using buckets and per-bucket linked-lists:
+    //! The following containers are node-based closed-addressing containers, implemented using buckets and per-bucket linked-lists:
     //! 1. @ref UnorderedMap
     //! 2. @ref UnorderedSet
     //! 3. @ref UnorderedMultiMap
@@ -31,13 +35,11 @@ namespace Luna
     //! 5. @ref SelfIndexedUnorderedMap
     //! 6. @ref SelfIndexedUnorderedMultiMap
     //! 
-    //! Open addressing (also known as closed hashing) algorithms store elements directly in hash table arrays, while closed addressing (also known as open hashing) algorithms allocate
-    //! dedicated memory for every element, and stores pointers to such elements in hash table arrays. In open-addressing containers, one hash table slot can only store on element, the
-    //! second element with the same hash value must be relocated to another empty slot; in closed-addressing containers, all elements with the same hash value can be stored in the same 
-    //! hash table slot, usually stored as linked lists. See [Open vs Closed Addressing](https://programming.guide/hash-tables-open-vs-closed-addressing.html) for a detailed comparison 
-    //! of open addressing and closed addressing.
-    //! 
-    //! Prefer @ref HashMap and @ref HashSet instead of @ref UnorderedMap and @ref UnorderedSet, since it performs better in memory fragmentation, memory locality and cache performance. 
+    //! Sparse-array hashing stores elements densely enough for cache-friendly iteration while leaving deleted slots reusable through a free list. Bucket chains store sparse-array indices,
+    //! so erasing one element does not relocate other elements.
+    //!
+    //! Prefer @ref HashMap and @ref HashSet instead of @ref UnorderedMap and @ref UnorderedSet for most unique-key maps and sets, since sparse-array hashing performs better in memory
+    //! fragmentation, memory locality and cache performance.
     //! Use @ref UnorderedMap and @ref UnorderedSet if you have the following requirements:
     //! 
     //! 1. You want to insert multiple elements with the same key to the map, which is only supported by closed-addressing maps. Use @ref UnorderedMultiMap, @ref SelfIndexedUnorderedMultiMap
@@ -65,12 +67,12 @@ namespace Luna
         using const_reference = const value_type&;
         using pointer = value_type*;
         using const_pointer = const value_type*;
-        using iterator = RobinHoodHashing::Iterator<value_type, false>;
-        using const_iterator = RobinHoodHashing::Iterator<value_type, true>;
+        using iterator = SparseHashing::Iterator<value_type, false>;
+        using const_iterator = SparseHashing::Iterator<value_type, true>;
 
     private:
 
-        using table_type = RobinHoodHashing::HashTable<key_type, value_type, Impl::MapExtractKey<key_type, value_type>, hasher, key_equal, allocator_type>;
+        using table_type = SparseHashing::HashTable<key_type, value_type, Impl::MapExtractKey<key_type, value_type>, hasher, key_equal, allocator_type>;
 
         table_type m_base;
 
@@ -200,7 +202,7 @@ namespace Luna
         //! will expand the hash table to bring more hash table slots.
         //! @param[in] ml The new load factor to set.
         //! @par Valid Usage
-        //! * `ml` must between [`0.0`, `1.0`].
+        //! * `ml` must be greater than `0.0`.
         void max_load_factor(f32 ml)
         {
             m_base.max_load_factor(ml);
@@ -210,8 +212,7 @@ namespace Luna
         {
             m_base.clear();
         }
-        //! Reduces the hash table size to a minimum value that satisfy the maximum load factor limitation.
-        //! @details The hash table size can be computed as: `ceilf((f32)size() / max_load_factor())`.
+        //! Reduces the sparse value array and hash table to the minimum size that satisfies the current element count and maximum load factor limitation.
         void shrink_to_fit()
         {
             m_base.shrink_to_fit();

--- a/Modules/Luna/Runtime/HashSet.hpp
+++ b/Modules/Luna/Runtime/HashSet.hpp
@@ -180,6 +180,20 @@ namespace Luna
         {
             m_base.shrink_to_fit();
         }
+        //! Sorts elements in non-descending order.
+        //! @remark This invalidates all iterators, references and pointers to elements.
+        void sort()
+        {
+            m_base.sort();
+        }
+        //! Sorts elements using the specified comparison function.
+        //! @param[in] comp The comparison function object, which returns `true` if the first value should be ordered before the second value.
+        //! @remark This invalidates all iterators, references and pointers to elements.
+        template <typename _Compare>
+        void sort(_Compare comp)
+        {
+            m_base.sort(comp);
+        }
         //! Gets the hash function used by this set.
         //! @return Returns the hash function used by this set.
         hasher hash_function() const

--- a/Modules/Luna/Runtime/HashSet.hpp
+++ b/Modules/Luna/Runtime/HashSet.hpp
@@ -8,7 +8,7 @@
 * @date 2022/5/1
 */
 #pragma once
-#include "Impl/RobinHoodHashTable.hpp"
+#include "Impl/SparseHashTable.hpp"
 #include "TypeInfo.hpp"
 
 namespace Luna
@@ -16,7 +16,7 @@ namespace Luna
     //! @addtogroup RuntimeContainer
     //! @{
     
-    //! An container that contains a set of unique objects using open-addressing hashing algorithm.
+    //! An container that contains a set of unique objects using sparse-array hashing algorithm.
     //! @remark See remarks of @ref HashMap for details.
     template <
         typename _Kty,
@@ -35,10 +35,10 @@ namespace Luna
         using const_reference = const value_type&;
         using pointer = value_type*;
         using const_pointer = const value_type*;
-        using iterator = RobinHoodHashing::Iterator<value_type, false>;
-        using const_iterator = RobinHoodHashing::Iterator<value_type, true>;
+        using iterator = SparseHashing::Iterator<value_type, false>;
+        using const_iterator = SparseHashing::Iterator<value_type, true>;
     private:
-        using table_type = RobinHoodHashing::HashTable<key_type, value_type, Impl::SetExtractKey<key_type, value_type>, hasher, key_equal, allocator_type>;
+        using table_type = SparseHashing::HashTable<key_type, value_type, Impl::SetExtractKey<key_type, value_type>, hasher, key_equal, allocator_type>;
         table_type m_base;
         HashSet(table_type&& base) :
             m_base(move(base)) {}
@@ -165,7 +165,7 @@ namespace Luna
         //! will expand the hash table to bring more hash table slots.
         //! @param[in] ml The new load factor to set.
         //! @par Valid Usage
-        //! * `ml` must between [`0.0`, `1.0`].
+        //! * `ml` must be greater than `0.0`.
         void max_load_factor(f32 ml)
         {
             m_base.max_load_factor(ml);
@@ -175,8 +175,7 @@ namespace Luna
         {
             m_base.clear();
         }
-        //! Reduces the hash table size to a minimum value that satisfy the maximum load factor limitation.
-        //! @details The hash table size can be computed as: `ceilf((f32)size() / max_load_factor())`.
+        //! Reduces the sparse value array and hash table to the minimum size that satisfies the current element count and maximum load factor limitation.
         void shrink_to_fit()
         {
             m_base.shrink_to_fit();

--- a/Modules/Luna/Runtime/Impl/SparseHashTable.hpp
+++ b/Modules/Luna/Runtime/Impl/SparseHashTable.hpp
@@ -1,0 +1,818 @@
+/*!
+* This file is a portion of LunaSDK.
+* For conditions of distribution and use, see the disclaimer
+* and license in LICENSE.txt
+*
+* @file SparseHashTable.hpp
+* @author JXMaster
+* @date 2026/6/3
+* @brief A hash table implementation that stores elements in a sparse array and
+* bucket chains by sparse-array index.
+*/
+#pragma once
+#include "../Base.hpp"
+#include "../Functional.hpp"
+#include "../Algorithm.hpp"
+#include "../Allocator.hpp"
+#include "../MemoryUtils.hpp"
+#include "HashTableBase.hpp"
+#include <cmath> // for ceilf
+
+namespace Luna
+{
+    namespace SparseHashing
+    {
+        constexpr usize EMPTY_SLOT = USIZE_MAX;
+        constexpr usize INITIAL_BUFFER_SIZE = 16;
+        constexpr f32 INITIAL_LOAD_FACTOR = 2.0f;
+
+        inline usize bitset_size(usize capacity)
+        {
+            return (capacity + 7) / 8;
+        }
+
+        inline usize round_up_power_of_two(usize value)
+        {
+            if (value <= 1) return value;
+            --value;
+            for (usize shift = 1; shift < sizeof(usize) * 8; shift <<= 1)
+            {
+                value |= value >> shift;
+            }
+            return value + 1;
+        }
+
+        inline usize minimum_bucket_count(usize size, f32 max_load_factor)
+        {
+            if (!size) return 0;
+            usize ret = (usize)ceilf((f32)size / max_load_factor);
+            return round_up_power_of_two(max(ret, (usize)1));
+        }
+
+        template <typename _Ty, bool _Const>
+        struct Iterator
+        {
+            using value_type = _Ty;
+            using pointer = conditional_t<_Const, const value_type*, value_type*>;
+            using reference = conditional_t<_Const, const value_type&, value_type&>;
+            using iterator_category = forward_iterator_tag;
+
+            pointer m_values;
+            const u8* m_occupied;
+            usize m_index;
+            usize m_end;
+
+            Iterator() :
+                m_values(nullptr),
+                m_occupied(nullptr),
+                m_index(0),
+                m_end(0) {}
+            Iterator(pointer values, const u8* occupied, usize index, usize end) :
+                m_values(values),
+                m_occupied(occupied),
+                m_index(index),
+                m_end(end)
+            {
+                skip_empty();
+            }
+            Iterator(const Iterator<_Ty, false>& rhs) :
+                m_values(rhs.m_values),
+                m_occupied(rhs.m_occupied),
+                m_index(rhs.m_index),
+                m_end(rhs.m_end) {}
+            reference operator*() const
+            {
+                return m_values[m_index];
+            }
+            pointer operator->() const
+            {
+                return m_values + m_index;
+            }
+            Iterator& operator++()
+            {
+                ++m_index;
+                skip_empty();
+                return *this;
+            }
+            Iterator operator++(int)
+            {
+                Iterator temp(*this);
+                ++(*this);
+                return temp;
+            }
+            bool operator==(const Iterator& rhs) const
+            {
+                return m_values == rhs.m_values && m_index == rhs.m_index;
+            }
+            bool operator!=(const Iterator& rhs) const
+            {
+                return !(*this == rhs);
+            }
+        private:
+            void skip_empty()
+            {
+                while (m_index < m_end && !bit_test(m_occupied, m_index))
+                {
+                    ++m_index;
+                }
+            }
+        };
+
+        template <typename _Kty,
+            typename _Vty,
+            typename _ExtractKey,
+            typename _Hash = hash<_Kty>,
+            typename _KeyEqual = equal_to<_Kty>,
+            typename _Alloc = Allocator>
+        class HashTable
+        {
+        public:
+            using key_type = _Kty;
+            using value_type = _Vty;
+            using allocator_type = _Alloc;
+            using hasher = _Hash;
+            using key_equal = _KeyEqual;
+            using reference = value_type&;
+            using const_reference = const value_type&;
+            using pointer = value_type*;
+            using const_pointer = const value_type*;
+            using iterator = Iterator<value_type, false>;
+            using const_iterator = Iterator<value_type, true>;
+            using extract_key = _ExtractKey;
+
+            // -------------------- Begin of ABI compatible part --------------------
+
+            OptionalPair<allocator_type, value_type*> m_allocator_and_values;
+            usize* m_hashes;
+            usize* m_nexts;
+            u8* m_occupied;
+            usize* m_buckets;
+            usize m_capacity;
+            usize m_sparse_size;
+            usize m_size;
+            usize m_first_free;
+            usize m_hole_count;
+            usize m_bucket_count;
+            f32 m_max_load_factor;
+
+            // --------------------  End of ABI compatible part  --------------------
+
+        private:
+            template <typename _Ty>
+            _Ty* allocate(usize n)
+            {
+                return m_allocator_and_values.first().template allocate<_Ty>(n);
+            }
+            template <typename _Ty>
+            void deallocate(_Ty* ptr, usize n)
+            {
+                m_allocator_and_values.first().template deallocate<_Ty>(ptr, n);
+            }
+            value_type* values() const
+            {
+                return m_allocator_and_values.second();
+            }
+            void initialize_bucket_buffer(usize* buckets, usize count)
+            {
+                for (usize i = 0; i < count; ++i)
+                {
+                    buckets[i] = EMPTY_SLOT;
+                }
+            }
+            void free_value_storage()
+            {
+                if (values())
+                {
+                    deallocate<value_type>(values(), m_capacity);
+                    m_allocator_and_values.second() = nullptr;
+                }
+                if (m_hashes)
+                {
+                    deallocate<usize>(m_hashes, m_capacity);
+                    m_hashes = nullptr;
+                }
+                if (m_nexts)
+                {
+                    deallocate<usize>(m_nexts, m_capacity);
+                    m_nexts = nullptr;
+                }
+                if (m_occupied)
+                {
+                    deallocate<u8>(m_occupied, bitset_size(m_capacity));
+                    m_occupied = nullptr;
+                }
+            }
+            void free_bucket_storage()
+            {
+                if (m_buckets)
+                {
+                    deallocate<usize>(m_buckets, m_bucket_count);
+                    m_buckets = nullptr;
+                }
+            }
+            void internal_reserve_values(usize new_capacity)
+            {
+                if (new_capacity <= m_capacity) return;
+                value_type* new_values = allocate<value_type>(new_capacity);
+                usize* new_hashes = allocate<usize>(new_capacity);
+                usize* new_nexts = allocate<usize>(new_capacity);
+                usize new_occupied_size = bitset_size(new_capacity);
+                u8* new_occupied = allocate<u8>(new_occupied_size);
+                memzero(new_occupied, new_occupied_size);
+                if (values())
+                {
+                    memcpy(new_hashes, m_hashes, sizeof(usize) * m_capacity);
+                    memcpy(new_nexts, m_nexts, sizeof(usize) * m_capacity);
+                    for (usize i = 0; i < m_sparse_size; ++i)
+                    {
+                        if (bit_test(m_occupied, i))
+                        {
+                            copy_relocate(new_values + i, values() + i);
+                            bit_set(new_occupied, i);
+                        }
+                    }
+                    free_value_storage();
+                }
+                m_allocator_and_values.second() = new_values;
+                m_hashes = new_hashes;
+                m_nexts = new_nexts;
+                m_occupied = new_occupied;
+                m_capacity = new_capacity;
+            }
+            void internal_clear()
+            {
+                for (usize i = 0; i < m_sparse_size; ++i)
+                {
+                    if (bit_test(m_occupied, i))
+                    {
+                        destruct(values() + i);
+                    }
+                }
+                if (m_occupied)
+                {
+                    memzero(m_occupied, bitset_size(m_capacity));
+                }
+                if (m_buckets)
+                {
+                    initialize_bucket_buffer(m_buckets, m_bucket_count);
+                }
+                m_sparse_size = 0;
+                m_size = 0;
+                m_first_free = EMPTY_SLOT;
+                m_hole_count = 0;
+            }
+            void internal_clear_and_free_table()
+            {
+                internal_clear();
+                free_value_storage();
+                free_bucket_storage();
+                m_capacity = 0;
+                m_bucket_count = 0;
+            }
+            void increment_reserve(usize new_cap)
+            {
+                if (new_cap > m_capacity)
+                {
+                    usize new_capacity = max(max(new_cap, m_capacity * 2), INITIAL_BUFFER_SIZE);
+                    internal_reserve_values(new_capacity);
+                }
+                usize desired_bucket_count = minimum_bucket_count(new_cap, m_max_load_factor);
+                if (desired_bucket_count > m_bucket_count)
+                {
+                    rehash(desired_bucket_count);
+                }
+            }
+            usize hash_key(const key_type& key) const
+            {
+                return hasher()(key);
+            }
+            iterator internal_find(const key_type& key, usize h)
+            {
+                if (!m_bucket_count) return end();
+                usize i = m_buckets[h % m_bucket_count];
+                while (i != EMPTY_SLOT)
+                {
+                    if (m_hashes[i] == h && key_equal()(key, extract_key()(values()[i])))
+                    {
+                        return iterator(values(), m_occupied, i, m_sparse_size);
+                    }
+                    i = m_nexts[i];
+                }
+                return end();
+            }
+            const_iterator internal_find(const key_type& key, usize h) const
+            {
+                if (!m_bucket_count) return end();
+                usize i = m_buckets[h % m_bucket_count];
+                while (i != EMPTY_SLOT)
+                {
+                    if (m_hashes[i] == h && key_equal()(key, extract_key()(values()[i])))
+                    {
+                        return const_iterator(values(), m_occupied, i, m_sparse_size);
+                    }
+                    i = m_nexts[i];
+                }
+                return end();
+            }
+            usize allocate_sparse_slot()
+            {
+                if (m_first_free != EMPTY_SLOT)
+                {
+                    usize ret = m_first_free;
+                    m_first_free = m_nexts[ret];
+                    --m_hole_count;
+                    bit_set(m_occupied, ret);
+                    return ret;
+                }
+                luassert(m_sparse_size < m_capacity);
+                usize ret = m_sparse_size++;
+                bit_set(m_occupied, ret);
+                return ret;
+            }
+            template <typename... _Args>
+            iterator internal_insert(usize h, _Args&&... args)
+            {
+                increment_reserve(m_size + 1);
+                usize pos = allocate_sparse_slot();
+                direct_construct(values() + pos, forward<_Args>(args)...);
+                m_hashes[pos] = h;
+                usize bucket = h % m_bucket_count;
+                m_nexts[pos] = m_buckets[bucket];
+                m_buckets[bucket] = pos;
+                ++m_size;
+                return iterator(values(), m_occupied, pos, m_sparse_size);
+            }
+            void internal_copy_from(const HashTable& rhs)
+            {
+                m_max_load_factor = rhs.m_max_load_factor;
+                if (rhs.m_size)
+                {
+                    reserve(rhs.m_size);
+                    for (usize i = 0; i < rhs.m_sparse_size; ++i)
+                    {
+                        if (bit_test(rhs.m_occupied, i))
+                        {
+                            insert(rhs.values()[i]);
+                        }
+                    }
+                }
+            }
+            void internal_move_from_with_different_allocator(HashTable& rhs)
+            {
+                m_max_load_factor = rhs.m_max_load_factor;
+                if (rhs.m_size)
+                {
+                    reserve(rhs.m_size);
+                    for (usize i = 0; i < rhs.m_sparse_size; ++i)
+                    {
+                        if (bit_test(rhs.m_occupied, i))
+                        {
+                            insert(move(rhs.values()[i]));
+                        }
+                    }
+                    rhs.clear();
+                }
+            }
+
+        public:
+            bool empty() const
+            {
+                return m_size == 0;
+            }
+            usize size() const
+            {
+                return m_size;
+            }
+            usize capacity() const
+            {
+                return m_capacity;
+            }
+            usize hash_table_size() const
+            {
+                return m_bucket_count;
+            }
+            f32 load_factor() const
+            {
+                if (!m_bucket_count) return 0.0f;
+                return (f32)m_size / (f32)m_bucket_count;
+            }
+            f32 max_load_factor() const
+            {
+                return m_max_load_factor;
+            }
+            void clear()
+            {
+                internal_clear();
+            }
+            void shrink_to_fit()
+            {
+                if (!m_size)
+                {
+                    internal_clear_and_free_table();
+                    return;
+                }
+                value_type* old_values = values();
+                usize* old_hashes = m_hashes;
+                usize* old_nexts = m_nexts;
+                u8* old_occupied = m_occupied;
+                usize old_capacity = m_capacity;
+                usize old_sparse_size = m_sparse_size;
+                value_type* new_values = allocate<value_type>(m_size);
+                usize* new_hashes = allocate<usize>(m_size);
+                usize* new_nexts = allocate<usize>(m_size);
+                u8* new_occupied = allocate<u8>(bitset_size(m_size));
+                memzero(new_occupied, bitset_size(m_size));
+                usize new_index = 0;
+                for (usize i = 0; i < old_sparse_size; ++i)
+                {
+                    if (bit_test(old_occupied, i))
+                    {
+                        copy_relocate(new_values + new_index, old_values + i);
+                        new_hashes[new_index] = old_hashes[i];
+                        bit_set(new_occupied, new_index);
+                        ++new_index;
+                    }
+                }
+                if (old_values) deallocate<value_type>(old_values, old_capacity);
+                if (old_hashes) deallocate<usize>(old_hashes, old_capacity);
+                if (old_nexts) deallocate<usize>(old_nexts, old_capacity);
+                if (old_occupied) deallocate<u8>(old_occupied, bitset_size(old_capacity));
+                m_allocator_and_values.second() = new_values;
+                m_hashes = new_hashes;
+                m_nexts = new_nexts;
+                m_occupied = new_occupied;
+                m_capacity = m_size;
+                m_sparse_size = m_size;
+                m_first_free = EMPTY_SLOT;
+                m_hole_count = 0;
+                rehash(minimum_bucket_count(m_size, m_max_load_factor));
+            }
+            hasher hash_function() const
+            {
+                return hasher();
+            }
+            key_equal key_eq() const
+            {
+                return key_equal();
+            }
+            void rehash(usize new_bucket_count)
+            {
+                new_bucket_count = round_up_power_of_two(max(new_bucket_count, minimum_bucket_count(m_size, m_max_load_factor)));
+                if (new_bucket_count == m_bucket_count)
+                {
+                    return;
+                }
+                usize* buckets = nullptr;
+                if (new_bucket_count)
+                {
+                    buckets = allocate<usize>(new_bucket_count);
+                    initialize_bucket_buffer(buckets, new_bucket_count);
+                    for (usize i = 0; i < m_sparse_size; ++i)
+                    {
+                        if (bit_test(m_occupied, i))
+                        {
+                            usize bucket = m_hashes[i] % new_bucket_count;
+                            m_nexts[i] = buckets[bucket];
+                            buckets[bucket] = i;
+                        }
+                    }
+                }
+                free_bucket_storage();
+                m_buckets = buckets;
+                m_bucket_count = new_bucket_count;
+            }
+            void reserve(usize new_cap)
+            {
+                if (new_cap > m_capacity)
+                {
+                    internal_reserve_values(new_cap);
+                }
+                usize desired_bucket_count = minimum_bucket_count(new_cap, m_max_load_factor);
+                if (desired_bucket_count > m_bucket_count)
+                {
+                    rehash(desired_bucket_count);
+                }
+            }
+            void max_load_factor(f32 ml)
+            {
+                lucheck(ml > 0.0f);
+                m_max_load_factor = ml;
+                if (load_factor() > m_max_load_factor)
+                {
+                    rehash(0);
+                }
+            }
+            HashTable() :
+                m_allocator_and_values(allocator_type(), nullptr),
+                m_hashes(nullptr),
+                m_nexts(nullptr),
+                m_occupied(nullptr),
+                m_buckets(nullptr),
+                m_capacity(0),
+                m_sparse_size(0),
+                m_size(0),
+                m_first_free(EMPTY_SLOT),
+                m_hole_count(0),
+                m_bucket_count(0),
+                m_max_load_factor(INITIAL_LOAD_FACTOR) {}
+            HashTable(const allocator_type& alloc) :
+                m_allocator_and_values(alloc, nullptr),
+                m_hashes(nullptr),
+                m_nexts(nullptr),
+                m_occupied(nullptr),
+                m_buckets(nullptr),
+                m_capacity(0),
+                m_sparse_size(0),
+                m_size(0),
+                m_first_free(EMPTY_SLOT),
+                m_hole_count(0),
+                m_bucket_count(0),
+                m_max_load_factor(INITIAL_LOAD_FACTOR) {}
+            HashTable(const HashTable& rhs) :
+                HashTable()
+            {
+                internal_copy_from(rhs);
+            }
+            HashTable(const HashTable& rhs, const allocator_type& alloc) :
+                HashTable(alloc)
+            {
+                internal_copy_from(rhs);
+            }
+            HashTable(HashTable&& rhs) :
+                m_allocator_and_values(move(rhs.m_allocator_and_values.first()), rhs.values()),
+                m_hashes(rhs.m_hashes),
+                m_nexts(rhs.m_nexts),
+                m_occupied(rhs.m_occupied),
+                m_buckets(rhs.m_buckets),
+                m_capacity(rhs.m_capacity),
+                m_sparse_size(rhs.m_sparse_size),
+                m_size(rhs.m_size),
+                m_first_free(rhs.m_first_free),
+                m_hole_count(rhs.m_hole_count),
+                m_bucket_count(rhs.m_bucket_count),
+                m_max_load_factor(rhs.m_max_load_factor)
+            {
+                rhs.m_allocator_and_values.second() = nullptr;
+                rhs.m_hashes = nullptr;
+                rhs.m_nexts = nullptr;
+                rhs.m_occupied = nullptr;
+                rhs.m_buckets = nullptr;
+                rhs.m_capacity = 0;
+                rhs.m_sparse_size = 0;
+                rhs.m_size = 0;
+                rhs.m_first_free = EMPTY_SLOT;
+                rhs.m_hole_count = 0;
+                rhs.m_bucket_count = 0;
+            }
+            HashTable(HashTable&& rhs, const allocator_type& alloc) :
+                HashTable(alloc)
+            {
+                if (m_allocator_and_values.first() == rhs.m_allocator_and_values.first())
+                {
+                    m_allocator_and_values.second() = rhs.values();
+                    m_hashes = rhs.m_hashes;
+                    m_nexts = rhs.m_nexts;
+                    m_occupied = rhs.m_occupied;
+                    m_buckets = rhs.m_buckets;
+                    m_capacity = rhs.m_capacity;
+                    m_sparse_size = rhs.m_sparse_size;
+                    m_size = rhs.m_size;
+                    m_first_free = rhs.m_first_free;
+                    m_hole_count = rhs.m_hole_count;
+                    m_bucket_count = rhs.m_bucket_count;
+                    m_max_load_factor = rhs.m_max_load_factor;
+                    rhs.m_allocator_and_values.second() = nullptr;
+                    rhs.m_hashes = nullptr;
+                    rhs.m_nexts = nullptr;
+                    rhs.m_occupied = nullptr;
+                    rhs.m_buckets = nullptr;
+                    rhs.m_capacity = 0;
+                    rhs.m_sparse_size = 0;
+                    rhs.m_size = 0;
+                    rhs.m_first_free = EMPTY_SLOT;
+                    rhs.m_hole_count = 0;
+                    rhs.m_bucket_count = 0;
+                }
+                else
+                {
+                    internal_move_from_with_different_allocator(rhs);
+                }
+            }
+            HashTable& operator=(const HashTable& rhs)
+            {
+                if (this != &rhs)
+                {
+                    internal_clear_and_free_table();
+                    internal_copy_from(rhs);
+                }
+                return *this;
+            }
+            HashTable& operator=(HashTable&& rhs)
+            {
+                if (this != &rhs)
+                {
+                    internal_clear_and_free_table();
+                    if (m_allocator_and_values.first() == rhs.m_allocator_and_values.first())
+                    {
+                        m_allocator_and_values.second() = rhs.values();
+                        m_hashes = rhs.m_hashes;
+                        m_nexts = rhs.m_nexts;
+                        m_occupied = rhs.m_occupied;
+                        m_buckets = rhs.m_buckets;
+                        m_capacity = rhs.m_capacity;
+                        m_sparse_size = rhs.m_sparse_size;
+                        m_size = rhs.m_size;
+                        m_first_free = rhs.m_first_free;
+                        m_hole_count = rhs.m_hole_count;
+                        m_bucket_count = rhs.m_bucket_count;
+                        m_max_load_factor = rhs.m_max_load_factor;
+                        rhs.m_allocator_and_values.second() = nullptr;
+                        rhs.m_hashes = nullptr;
+                        rhs.m_nexts = nullptr;
+                        rhs.m_occupied = nullptr;
+                        rhs.m_buckets = nullptr;
+                        rhs.m_capacity = 0;
+                        rhs.m_sparse_size = 0;
+                        rhs.m_size = 0;
+                        rhs.m_first_free = EMPTY_SLOT;
+                        rhs.m_hole_count = 0;
+                        rhs.m_bucket_count = 0;
+                    }
+                    else
+                    {
+                        internal_move_from_with_different_allocator(rhs);
+                    }
+                }
+                return *this;
+            }
+            ~HashTable()
+            {
+                internal_clear_and_free_table();
+            }
+            iterator begin()
+            {
+                return iterator(values(), m_occupied, 0, m_sparse_size);
+            }
+            const_iterator begin() const
+            {
+                return const_iterator(values(), m_occupied, 0, m_sparse_size);
+            }
+            const_iterator cbegin() const
+            {
+                return begin();
+            }
+            iterator end()
+            {
+                return iterator(values(), m_occupied, m_sparse_size, m_sparse_size);
+            }
+            const_iterator end() const
+            {
+                return const_iterator(values(), m_occupied, m_sparse_size, m_sparse_size);
+            }
+            const_iterator cend() const
+            {
+                return end();
+            }
+            iterator find(const key_type& key)
+            {
+                usize h = hash_key(key);
+                return internal_find(key, h);
+            }
+            const_iterator find(const key_type& key) const
+            {
+                usize h = hash_key(key);
+                return internal_find(key, h);
+            }
+            bool contains(const key_type& key) const
+            {
+                auto iter = find(key);
+                return iter != end();
+            }
+            usize count(const key_type& key) const
+            {
+                return contains(key) ? 1 : 0;
+            }
+            Pair<iterator, bool> insert(const value_type& value)
+            {
+                usize h = hash_key(extract_key()(value));
+                auto iter = internal_find(extract_key()(value), h);
+                if (iter != end())
+                {
+                    return make_pair(iter, false);
+                }
+                return make_pair(internal_insert(h, value), true);
+            }
+            Pair<iterator, bool> insert(value_type&& value)
+            {
+                usize h = hash_key(extract_key()(value));
+                auto iter = internal_find(extract_key()(value), h);
+                if (iter != end())
+                {
+                    return make_pair(iter, false);
+                }
+                return make_pair(internal_insert(h, move(value)), true);
+            }
+            Pair<iterator, bool> insert_or_assign(const value_type& value)
+            {
+                usize h = hash_key(extract_key()(value));
+                auto iter = internal_find(extract_key()(value), h);
+                if (iter != end())
+                {
+                    (*iter) = value;
+                    return make_pair(iter, false);
+                }
+                return make_pair(internal_insert(h, value), true);
+            }
+            Pair<iterator, bool> insert_or_assign(value_type&& value)
+            {
+                usize h = hash_key(extract_key()(value));
+                auto iter = internal_find(extract_key()(value), h);
+                if (iter != end())
+                {
+                    (*iter) = move(value);
+                    return make_pair(iter, false);
+                }
+                return make_pair(internal_insert(h, move(value)), true);
+            }
+            template <typename _M>
+            Pair<iterator, bool> insert_or_assign(const key_type& key, _M&& value)
+            {
+                usize h = hash_key(key);
+                auto iter = internal_find(key, h);
+                if (iter != end())
+                {
+                    iter->second = forward<_M>(value);
+                    return make_pair(iter, false);
+                }
+                return make_pair(internal_insert(h, value_type(key, forward<_M>(value))), true);
+            }
+            template <typename _M>
+            Pair<iterator, bool> insert_or_assign(key_type&& key, _M&& value)
+            {
+                usize h = hash_key(key);
+                auto iter = internal_find(key, h);
+                if (iter != end())
+                {
+                    iter->second = forward<_M>(value);
+                    return make_pair(iter, false);
+                }
+                return make_pair(internal_insert(h, value_type(move(key), forward<_M>(value))), true);
+            }
+            template <typename... _Args>
+            Pair<iterator, bool> emplace(_Args&&... args)
+            {
+                Unconstructed<value_type> value;
+                value.construct(forward<_Args>(args)...);
+                usize h = hash_key(extract_key()(value.get()));
+                iterator iter = internal_find(extract_key()(value.get()), h);
+                if (iter != end())
+                {
+                    value.destruct();
+                    return make_pair(iter, false);
+                }
+                increment_reserve(m_size + 1);
+                usize pos = allocate_sparse_slot();
+                copy_relocate(values() + pos, &(value.get()));
+                m_hashes[pos] = h;
+                usize bucket = h % m_bucket_count;
+                m_nexts[pos] = m_buckets[bucket];
+                m_buckets[bucket] = pos;
+                ++m_size;
+                return make_pair(iterator(values(), m_occupied, pos, m_sparse_size), true);
+            }
+            iterator erase(const_iterator pos)
+            {
+                usize index = pos.m_index;
+                luassert(index < m_sparse_size && bit_test(m_occupied, index));
+                usize bucket = m_hashes[index] % m_bucket_count;
+                usize* link = m_buckets + bucket;
+                while (*link != index)
+                {
+                    link = m_nexts + *link;
+                }
+                *link = m_nexts[index];
+                destruct(values() + index);
+                bit_reset(m_occupied, index);
+                m_nexts[index] = m_first_free;
+                m_first_free = index;
+                ++m_hole_count;
+                --m_size;
+                return iterator(values(), m_occupied, index + 1, m_sparse_size);
+            }
+            usize erase(const key_type& key)
+            {
+                auto iter = find(key);
+                if (iter != end())
+                {
+                    erase(iter);
+                    return 1;
+                }
+                return 0;
+            }
+            allocator_type get_allocator() const
+            {
+                return m_allocator_and_values.first();
+            }
+        };
+    }
+}

--- a/Modules/Luna/Runtime/Impl/SparseHashTable.hpp
+++ b/Modules/Luna/Runtime/Impl/SparseHashTable.hpp
@@ -179,6 +179,19 @@ namespace Luna
                     buckets[i] = EMPTY_SLOT;
                 }
             }
+            void rebuild_bucket_chains(usize* buckets, usize bucket_count)
+            {
+                initialize_bucket_buffer(buckets, bucket_count);
+                for (usize i = 0; i < m_sparse_size; ++i)
+                {
+                    if (bit_test(m_occupied, i))
+                    {
+                        usize bucket = m_hashes[i] % bucket_count;
+                        m_nexts[i] = buckets[bucket];
+                        buckets[bucket] = i;
+                    }
+                }
+            }
             void free_value_storage()
             {
                 if (values())
@@ -445,7 +458,87 @@ namespace Luna
                 m_sparse_size = m_size;
                 m_first_free = EMPTY_SLOT;
                 m_hole_count = 0;
-                rehash(minimum_bucket_count(m_size, m_max_load_factor));
+                usize desired_bucket_count = minimum_bucket_count(m_size, m_max_load_factor);
+                if (desired_bucket_count == m_bucket_count)
+                {
+                    rebuild_bucket_chains(m_buckets, m_bucket_count);
+                }
+                else
+                {
+                    rehash(desired_bucket_count);
+                }
+            }
+            //! Sorts elements by sparse-array iteration order and rebuilds hash bucket chains.
+            //! @remark This invalidates all iterators, references and pointers to elements.
+            template <typename _Compare>
+            void sort(_Compare comp)
+            {
+                if (!m_size || (m_size == 1 && !m_hole_count))
+                {
+                    return;
+                }
+                usize* order = allocate<usize>(m_size);
+                usize order_size = 0;
+                for (usize i = 0; i < m_sparse_size; ++i)
+                {
+                    if (bit_test(m_occupied, i))
+                    {
+                        order[order_size++] = i;
+                    }
+                }
+                luassert(order_size == m_size);
+                if (m_size > 1)
+                {
+                    value_type* old_values = values();
+                    Luna::sort(order, order + m_size, [old_values, comp](usize lhs, usize rhs) {
+                        return comp(old_values[lhs], old_values[rhs]);
+                    });
+                }
+
+                value_type* old_values = values();
+                usize* old_hashes = m_hashes;
+                usize* old_nexts = m_nexts;
+                u8* old_occupied = m_occupied;
+                usize old_capacity = m_capacity;
+                value_type* new_values = allocate<value_type>(m_capacity);
+                usize* new_hashes = allocate<usize>(m_capacity);
+                usize* new_nexts = allocate<usize>(m_capacity);
+                u8* new_occupied = allocate<u8>(bitset_size(m_capacity));
+                memzero(new_occupied, bitset_size(m_capacity));
+                for (usize i = 0; i < m_size; ++i)
+                {
+                    usize old_index = order[i];
+                    copy_relocate(new_values + i, old_values + old_index);
+                    new_hashes[i] = old_hashes[old_index];
+                    bit_set(new_occupied, i);
+                }
+                deallocate<value_type>(old_values, old_capacity);
+                deallocate<usize>(old_hashes, old_capacity);
+                deallocate<usize>(old_nexts, old_capacity);
+                deallocate<u8>(old_occupied, bitset_size(old_capacity));
+                deallocate<usize>(order, m_size);
+
+                m_allocator_and_values.second() = new_values;
+                m_hashes = new_hashes;
+                m_nexts = new_nexts;
+                m_occupied = new_occupied;
+                m_sparse_size = m_size;
+                m_first_free = EMPTY_SLOT;
+                m_hole_count = 0;
+                if (m_bucket_count)
+                {
+                    rebuild_bucket_chains(m_buckets, m_bucket_count);
+                }
+                else
+                {
+                    rehash(minimum_bucket_count(m_size, m_max_load_factor));
+                }
+            }
+            //! Sorts elements in non-descending order.
+            //! @remark This invalidates all iterators, references and pointers to elements.
+            void sort()
+            {
+                sort(less<value_type>());
             }
             hasher hash_function() const
             {
@@ -466,16 +559,7 @@ namespace Luna
                 if (new_bucket_count)
                 {
                     buckets = allocate<usize>(new_bucket_count);
-                    initialize_bucket_buffer(buckets, new_bucket_count);
-                    for (usize i = 0; i < m_sparse_size; ++i)
-                    {
-                        if (bit_test(m_occupied, i))
-                        {
-                            usize bucket = m_hashes[i] % new_bucket_count;
-                            m_nexts[i] = buckets[bucket];
-                            buckets[bucket] = i;
-                        }
-                    }
+                    rebuild_bucket_chains(buckets, new_bucket_count);
                 }
                 free_bucket_storage();
                 m_buckets = buckets;

--- a/Modules/Luna/Runtime/RobinMap.hpp
+++ b/Modules/Luna/Runtime/RobinMap.hpp
@@ -1,0 +1,216 @@
+/*!
+* This file is a portion of LunaSDK.
+* For conditions of distribution and use, see the disclaimer
+* and license in LICENSE.txt
+*
+* @file RobinMap.hpp
+* @author JXMaster
+* @date 2026/6/3
+*/
+#pragma once
+#include "Impl/RobinHoodHashTable.hpp"
+
+namespace Luna
+{
+    //! @addtogroup RuntimeContainer
+    //! @{
+
+    //! An container that contains key-value pairs with unique keys using Robin Hood open-addressing hashing algorithm.
+    template <
+        typename _Kty,
+        typename _Ty,
+        typename _Hash = hash<_Kty>,
+        typename _KeyEqual = equal_to<_Kty>,
+        typename _Alloc = Allocator>
+    class RobinMap
+    {
+    public:
+        using key_type = _Kty;
+        using mapped_type = _Ty;
+        using value_type = Pair<const _Kty, _Ty>;
+        using allocator_type = _Alloc;
+        using hasher = _Hash;
+        using key_equal = _KeyEqual;
+        using reference = value_type&;
+        using const_reference = const value_type&;
+        using pointer = value_type*;
+        using const_pointer = const value_type*;
+        using iterator = RobinHoodHashing::Iterator<value_type, false>;
+        using const_iterator = RobinHoodHashing::Iterator<value_type, true>;
+    private:
+        using table_type = RobinHoodHashing::HashTable<key_type, value_type, Impl::MapExtractKey<key_type, value_type>, hasher, key_equal, allocator_type>;
+        table_type m_base;
+        RobinMap(table_type&& base) :
+            m_base(move(base)) {}
+    public:
+        RobinMap() :
+            m_base() {}
+        RobinMap(const allocator_type& alloc) :
+            m_base(alloc) {}
+        RobinMap(const RobinMap& rhs) :
+            m_base(rhs.m_base) {}
+        RobinMap(const RobinMap& rhs, const allocator_type& alloc) :
+            m_base(rhs.m_base, alloc) {}
+        RobinMap(RobinMap&& rhs) :
+            m_base(move(rhs.m_base)) {}
+        RobinMap(RobinMap&& rhs, const allocator_type& alloc) :
+            m_base(move(rhs.m_base), alloc) {}
+        RobinMap& operator=(const RobinMap& rhs)
+        {
+            m_base = rhs.m_base;
+            return *this;
+        }
+        RobinMap& operator=(RobinMap&& rhs)
+        {
+            m_base = move(rhs.m_base);
+            return *this;
+        }
+        iterator begin()
+        {
+            return m_base.begin();
+        }
+        const_iterator begin() const
+        {
+            return m_base.begin();
+        }
+        const_iterator cbegin() const
+        {
+            return m_base.cbegin();
+        }
+        iterator end()
+        {
+            return m_base.end();
+        }
+        const_iterator end() const
+        {
+            return m_base.end();
+        }
+        const_iterator cend() const
+        {
+            return m_base.cend();
+        }
+        bool empty() const
+        {
+            return m_base.empty();
+        }
+        usize size() const
+        {
+            return m_base.size();
+        }
+        usize capacity() const
+        {
+            return m_base.capacity();
+        }
+        usize hash_table_size() const
+        {
+            return m_base.hash_table_size();
+        }
+        f32 load_factor() const
+        {
+            return m_base.load_factor();
+        }
+        f32 max_load_factor() const
+        {
+            return m_base.max_load_factor();
+        }
+        void max_load_factor(f32 ml)
+        {
+            m_base.max_load_factor(ml);
+        }
+        void clear()
+        {
+            m_base.clear();
+        }
+        void shrink_to_fit()
+        {
+            m_base.shrink_to_fit();
+        }
+        hasher hash_function() const
+        {
+            return m_base.hash_function();
+        }
+        key_equal key_eq() const
+        {
+            return m_base.key_eq();
+        }
+        void rehash(usize new_data_table_size)
+        {
+            m_base.rehash(new_data_table_size);
+        }
+        void reserve(usize new_cap)
+        {
+            m_base.reserve(new_cap);
+        }
+        iterator find(const key_type& key)
+        {
+            return m_base.find(key);
+        }
+        const_iterator find(const key_type& key) const
+        {
+            return m_base.find(key);
+        }
+        mapped_type& operator[](const key_type& key)
+        {
+            auto iter = find(key);
+            luassert(iter != end());
+            return iter->second;
+        }
+        const mapped_type& operator[](const key_type& key) const
+        {
+            auto iter = find(key);
+            luassert(iter != end());
+            return iter->second;
+        }
+        usize count(const key_type& key) const
+        {
+            return m_base.count(key);
+        }
+        bool contains(const key_type& key) const
+        {
+            return m_base.contains(key);
+        }
+        Pair<iterator, bool> insert(const value_type& value)
+        {
+            return m_base.insert(value);
+        }
+        Pair<iterator, bool> insert(value_type&& value)
+        {
+            return m_base.insert(move(value));
+        }
+        template <typename _M>
+        Pair<iterator, bool> insert_or_assign(const key_type& key, _M&& value)
+        {
+            return m_base.template insert_or_assign<_M>(key, forward<_M>(value));
+        }
+        template <typename _M>
+        Pair<iterator, bool> insert_or_assign(key_type&& key, _M&& value)
+        {
+            return m_base.template insert_or_assign<_M>(move(key), forward<_M>(value));
+        }
+        template <typename... _Args>
+        Pair<iterator, bool> emplace(_Args&&... args)
+        {
+            return m_base.emplace(forward<_Args>(args)...);
+        }
+        iterator erase(const_iterator pos)
+        {
+            return m_base.erase(pos);
+        }
+        usize erase(const key_type& key)
+        {
+            return m_base.erase(key);
+        }
+        void swap(RobinMap& rhs)
+        {
+            RobinMap tmp(move(rhs));
+            rhs = move(*this);
+            *this = move(tmp);
+        }
+        allocator_type get_allocator() const
+        {
+            return m_base.get_allocator();
+        }
+    };
+
+    //! @}
+}

--- a/Modules/Luna/Runtime/RobinSet.hpp
+++ b/Modules/Luna/Runtime/RobinSet.hpp
@@ -1,0 +1,192 @@
+/*!
+* This file is a portion of LunaSDK.
+* For conditions of distribution and use, see the disclaimer
+* and license in LICENSE.txt
+*
+* @file RobinSet.hpp
+* @author JXMaster
+* @date 2026/6/3
+*/
+#pragma once
+#include "Impl/RobinHoodHashTable.hpp"
+
+namespace Luna
+{
+    //! @addtogroup RuntimeContainer
+    //! @{
+
+    //! An container that contains a set of unique objects using Robin Hood open-addressing hashing algorithm.
+    template <
+        typename _Kty,
+        typename _Hash = hash<_Kty>,
+        typename _KeyEqual = equal_to<_Kty>,
+        typename _Alloc = Allocator>
+    class RobinSet
+    {
+    public:
+        using key_type = _Kty;
+        using value_type = _Kty;
+        using allocator_type = _Alloc;
+        using hasher = _Hash;
+        using key_equal = _KeyEqual;
+        using reference = value_type&;
+        using const_reference = const value_type&;
+        using pointer = value_type*;
+        using const_pointer = const value_type*;
+        using iterator = RobinHoodHashing::Iterator<value_type, false>;
+        using const_iterator = RobinHoodHashing::Iterator<value_type, true>;
+    private:
+        using table_type = RobinHoodHashing::HashTable<key_type, value_type, Impl::SetExtractKey<key_type, value_type>, hasher, key_equal, allocator_type>;
+        table_type m_base;
+        RobinSet(table_type&& base) :
+            m_base(move(base)) {}
+    public:
+        RobinSet() :
+            m_base() {}
+        RobinSet(const allocator_type& alloc) :
+            m_base(alloc) {}
+        RobinSet(const RobinSet& rhs) :
+            m_base(rhs.m_base) {}
+        RobinSet(const RobinSet& rhs, const allocator_type& alloc) :
+            m_base(rhs.m_base, alloc) {}
+        RobinSet(RobinSet&& rhs) :
+            m_base(move(rhs.m_base)) {}
+        RobinSet(RobinSet&& rhs, const allocator_type& alloc) :
+            m_base(move(rhs.m_base), alloc) {}
+        RobinSet& operator=(const RobinSet& rhs)
+        {
+            m_base = rhs.m_base;
+            return *this;
+        }
+        RobinSet& operator=(RobinSet&& rhs)
+        {
+            m_base = move(rhs.m_base);
+            return *this;
+        }
+        iterator begin()
+        {
+            return m_base.begin();
+        }
+        const_iterator begin() const
+        {
+            return m_base.begin();
+        }
+        const_iterator cbegin() const
+        {
+            return m_base.cbegin();
+        }
+        iterator end()
+        {
+            return m_base.end();
+        }
+        const_iterator end() const
+        {
+            return m_base.end();
+        }
+        const_iterator cend() const
+        {
+            return m_base.cend();
+        }
+        bool empty() const
+        {
+            return m_base.empty();
+        }
+        usize size() const
+        {
+            return m_base.size();
+        }
+        usize capacity() const
+        {
+            return m_base.capacity();
+        }
+        usize hash_table_size() const
+        {
+            return m_base.hash_table_size();
+        }
+        f32 load_factor() const
+        {
+            return m_base.load_factor();
+        }
+        f32 max_load_factor() const
+        {
+            return m_base.max_load_factor();
+        }
+        void max_load_factor(f32 ml)
+        {
+            m_base.max_load_factor(ml);
+        }
+        void clear()
+        {
+            m_base.clear();
+        }
+        void shrink_to_fit()
+        {
+            m_base.shrink_to_fit();
+        }
+        hasher hash_function() const
+        {
+            return m_base.hash_function();
+        }
+        key_equal key_eq() const
+        {
+            return m_base.key_eq();
+        }
+        void rehash(usize new_buckets_count)
+        {
+            m_base.rehash(new_buckets_count);
+        }
+        void reserve(usize new_cap)
+        {
+            m_base.reserve(new_cap);
+        }
+        iterator find(const key_type& key)
+        {
+            return m_base.find(key);
+        }
+        const_iterator find(const key_type& key) const
+        {
+            return m_base.find(key);
+        }
+        usize count(const key_type& key) const
+        {
+            return m_base.count(key);
+        }
+        bool contains(const key_type& key) const
+        {
+            return m_base.contains(key);
+        }
+        Pair<iterator, bool> insert(const value_type& value)
+        {
+            return m_base.insert(value);
+        }
+        Pair<iterator, bool> insert(value_type&& value)
+        {
+            return m_base.insert(move(value));
+        }
+        template <typename... _Args>
+        Pair<iterator, bool> emplace(_Args&&... args)
+        {
+            return m_base.emplace(forward<_Args>(args)...);
+        }
+        iterator erase(const_iterator pos)
+        {
+            return m_base.erase(pos);
+        }
+        usize erase(const key_type& key)
+        {
+            return m_base.erase(key);
+        }
+        void swap(RobinSet& rhs)
+        {
+            RobinSet tmp(move(rhs));
+            rhs = move(*this);
+            *this = move(tmp);
+        }
+        allocator_type get_allocator() const
+        {
+            return m_base.get_allocator();
+        }
+    };
+
+    //! @}
+}

--- a/Modules/Luna/Runtime/Source/BuiltInTypeInfo.cpp
+++ b/Modules/Luna/Runtime/Source/BuiltInTypeInfo.cpp
@@ -422,128 +422,219 @@ namespace Luna
         lucatchret;
         return ok;
     }
-    inline usize robinhood_insert(usize h, typeinfo_t value_type, usize value_size, usize value_alignment, void* src_buf, void* value_buf, RobinHoodHashing::ControlBlock* cb_buf, usize buffer_size)
-    {
-        luassert(h != RobinHoodHashing::EMPTY_SLOT && !RobinHoodHashing::is_tombstone(h));
-        // Extract current data.
-        usize pos = h % buffer_size;
-        usize dist = 0;
-        usize ret_pos = USIZE_MAX;
-        void* temp_v = nullptr;
-        while (true)
-        {
-            if (cb_buf[pos].m_hash == RobinHoodHashing::EMPTY_SLOT)
-            {
-                cb_buf[pos].m_hash = h;
-                void* dst = (void*)((usize)value_buf + pos * value_size);
-                relocate_type(value_type, dst, src_buf);
-                if (ret_pos == USIZE_MAX) ret_pos = pos;
-                break;
-            }
-            usize existing_dist = RobinHoodHashing::probe_distance(cb_buf[pos].m_hash, pos, buffer_size);
-            if ((existing_dist <= dist) && RobinHoodHashing::is_tombstone(cb_buf[pos].m_hash))
-            {
-                cb_buf[pos].m_hash = h;
-                void* dst = (void*)((usize)value_buf + pos * value_size);
-                relocate_type(value_type, dst, src_buf);
-                if (ret_pos == USIZE_MAX) ret_pos = pos;
-                break;
-            }
-            if (existing_dist < dist)
-            {
-                usize temp_h = cb_buf[pos].m_hash;
-                cb_buf[pos].m_hash = h;
-                h = temp_h;
-                void* dst = (void*)((usize)value_buf + pos * value_size);
-                if(!temp_v) temp_v = memalloc(value_size, value_alignment);
-                relocate_type(value_type, temp_v, dst);
-                relocate_type(value_type, dst, src_buf);
-                relocate_type(value_type, src_buf, temp_v);
-                dist = existing_dist;
-                if (ret_pos == USIZE_MAX) ret_pos = pos;
-            }
-            ++pos;
-            ++dist;
-            if (pos == buffer_size)
-                pos = 0;
-        }
-        if(temp_v) memfree(temp_v, value_alignment);
-        return ret_pos;
-    }
     struct HashTableData
     {
         void* m_value_buffer;
-        RobinHoodHashing::ControlBlock* m_cb_buffer;
-        usize m_buffer_size;
+        usize* m_hashes;
+        usize* m_nexts;
+        u8* m_occupied;
+        usize* m_buckets;
+        usize m_capacity;
+        usize m_sparse_size;
         usize m_size;
+        usize m_first_free;
+        usize m_hole_count;
+        usize m_bucket_count;
         f32 m_max_load_factor;
 
+        usize bitset_size() const
+        {
+            return SparseHashing::bitset_size(m_capacity);
+        }
+        void* value_at(typeinfo_t value_type, usize index) const
+        {
+            return (void*)((usize)m_value_buffer + index * get_type_size(value_type));
+        }
+        void initialize_bucket_buffer(usize* buckets, usize count)
+        {
+            for (usize i = 0; i < count; ++i)
+            {
+                buckets[i] = SparseHashing::EMPTY_SLOT;
+            }
+        }
+        usize minimum_bucket_count(usize size) const
+        {
+            return SparseHashing::minimum_bucket_count(size, m_max_load_factor);
+        }
+        void clear(typeinfo_t value_type)
+        {
+            for (usize i = 0; i < m_sparse_size; ++i)
+            {
+                if (bit_test(m_occupied, i))
+                {
+                    destruct_type(value_type, value_at(value_type, i));
+                }
+            }
+            if (m_occupied)
+            {
+                memzero(m_occupied, bitset_size());
+            }
+            if (m_buckets)
+            {
+                initialize_bucket_buffer(m_buckets, m_bucket_count);
+            }
+            m_sparse_size = 0;
+            m_size = 0;
+            m_first_free = SparseHashing::EMPTY_SLOT;
+            m_hole_count = 0;
+        }
         void clear_and_free_table(typeinfo_t value_type)
         {
-            for (usize i = 0; i < m_buffer_size; ++i)
-            {
-                usize h = m_cb_buffer[i].m_hash;
-                if (h == RobinHoodHashing::EMPTY_SLOT || RobinHoodHashing::is_tombstone(h)) continue;
-                destruct_type(value_type, (void*)((usize)m_value_buffer + i * get_type_size(value_type)));
-            }
+            clear(value_type);
             if (m_value_buffer)
             {
-                memfree(m_value_buffer);
-                memfree(m_cb_buffer);
+                memfree(m_value_buffer, get_type_alignment(value_type));
                 m_value_buffer = nullptr;
             }
-            m_buffer_size = 0;
+            if (m_hashes)
+            {
+                memfree(m_hashes);
+                m_hashes = nullptr;
+            }
+            if (m_nexts)
+            {
+                memfree(m_nexts);
+                m_nexts = nullptr;
+            }
+            if (m_occupied)
+            {
+                memfree(m_occupied);
+                m_occupied = nullptr;
+            }
+            if (m_buckets)
+            {
+                memfree(m_buckets);
+                m_buckets = nullptr;
+            }
+            m_capacity = 0;
+            m_bucket_count = 0;
             m_size = 0;
         }
         f32 load_factor()
         {
-            if (!m_buffer_size)
+            if (!m_bucket_count)
             {
                 return 0.0f;
             }
-            return (f32)m_size / (f32)m_buffer_size;
+            return (f32)m_size / (f32)m_bucket_count;
         }
-        void rehash(typeinfo_t value_type, usize new_buffer_size)
+        void reserve_values(typeinfo_t value_type, usize new_capacity)
         {
-            new_buffer_size = max(max(new_buffer_size, (usize)(ceilf((f32)m_size / m_max_load_factor))), RobinHoodHashing::INITIAL_BUFFER_SIZE);
-            if (new_buffer_size == m_buffer_size)
+            if (new_capacity <= m_capacity) return;
+            usize value_size = get_type_size(value_type);
+            usize value_alignment = get_type_alignment(value_type);
+            void* new_values = memalloc(new_capacity * value_size, value_alignment);
+            usize* new_hashes = (usize*)memalloc(new_capacity * sizeof(usize));
+            usize* new_nexts = (usize*)memalloc(new_capacity * sizeof(usize));
+            usize new_occupied_size = SparseHashing::bitset_size(new_capacity);
+            u8* new_occupied = (u8*)memalloc(new_occupied_size);
+            memzero(new_occupied, new_occupied_size);
+            if (m_value_buffer)
+            {
+                memcpy(new_hashes, m_hashes, sizeof(usize) * m_capacity);
+                memcpy(new_nexts, m_nexts, sizeof(usize) * m_capacity);
+                for (usize i = 0; i < m_sparse_size; ++i)
+                {
+                    if (bit_test(m_occupied, i))
+                    {
+                        relocate_type(value_type, (void*)((usize)new_values + i * value_size), value_at(value_type, i));
+                        bit_set(new_occupied, i);
+                    }
+                }
+                memfree(m_value_buffer, value_alignment);
+                memfree(m_hashes);
+                memfree(m_nexts);
+                memfree(m_occupied);
+            }
+            m_value_buffer = new_values;
+            m_hashes = new_hashes;
+            m_nexts = new_nexts;
+            m_occupied = new_occupied;
+            m_capacity = new_capacity;
+        }
+        void rehash(typeinfo_t value_type, usize new_bucket_count)
+        {
+            new_bucket_count = SparseHashing::round_up_power_of_two(max(new_bucket_count, minimum_bucket_count(m_size)));
+            if (new_bucket_count == m_bucket_count)
             {
                 return;
             }
-            usize value_size = get_type_size(value_type);
-            usize value_alignment = get_type_alignment(value_type);
-            void* value_buf = memalloc(new_buffer_size * value_size, value_alignment);
-            RobinHoodHashing::ControlBlock* cb_buf = (RobinHoodHashing::ControlBlock*)memalloc(new_buffer_size * sizeof(RobinHoodHashing::ControlBlock));
-            memzero(cb_buf, new_buffer_size * sizeof(RobinHoodHashing::ControlBlock));
-            for (usize i = 0; i < m_buffer_size; ++i)
+            usize* buckets = nullptr;
+            if (new_bucket_count)
             {
-                usize h = m_cb_buffer[i].m_hash;
-                if (h == RobinHoodHashing::EMPTY_SLOT || RobinHoodHashing::is_tombstone(h)) continue;
-                void* src = (void*)((usize)m_value_buffer + i * value_size);
-                robinhood_insert(h, value_type, value_size, value_alignment, src, value_buf, cb_buf, new_buffer_size);
+                buckets = (usize*)memalloc(new_bucket_count * sizeof(usize));
+                initialize_bucket_buffer(buckets, new_bucket_count);
+                for (usize i = 0; i < m_sparse_size; ++i)
+                {
+                    if (bit_test(m_occupied, i))
+                    {
+                        usize bucket = m_hashes[i] % new_bucket_count;
+                        m_nexts[i] = buckets[bucket];
+                        buckets[bucket] = i;
+                    }
+                }
             }
-            if (m_value_buffer)
+            if (m_buckets)
             {
-                memfree(m_value_buffer);
-                memfree(m_cb_buffer);
-                m_value_buffer = nullptr;
+                memfree(m_buckets);
             }
-            m_value_buffer = value_buf;
-            m_cb_buffer = cb_buf;
-            m_buffer_size = new_buffer_size;
+            m_buckets = buckets;
+            m_bucket_count = new_bucket_count;
         }
         usize capacity() const
         {
-            return (usize)floorf(m_max_load_factor * m_buffer_size);
+            return m_capacity;
         }
         void increment_reserve(typeinfo_t value_type, usize new_cap)
         {
             usize current_capacity = capacity();
             if (new_cap > current_capacity)
             {
-                new_cap = max(new_cap, current_capacity * 2);
-                rehash(value_type, (usize)ceilf((f32)new_cap / m_max_load_factor));
+                reserve_values(value_type, max(max(new_cap, current_capacity * 2), SparseHashing::INITIAL_BUFFER_SIZE));
             }
+            usize desired_bucket_count = minimum_bucket_count(new_cap);
+            if (desired_bucket_count > m_bucket_count)
+            {
+                rehash(value_type, desired_bucket_count);
+            }
+        }
+        usize allocate_sparse_slot()
+        {
+            if (m_first_free != SparseHashing::EMPTY_SLOT)
+            {
+                usize ret = m_first_free;
+                m_first_free = m_nexts[ret];
+                --m_hole_count;
+                bit_set(m_occupied, ret);
+                return ret;
+            }
+            luassert(m_sparse_size < m_capacity);
+            usize ret = m_sparse_size++;
+            bit_set(m_occupied, ret);
+            return ret;
+        }
+        void link_slot(usize index, usize hash)
+        {
+            m_hashes[index] = hash;
+            usize bucket = hash % m_bucket_count;
+            m_nexts[index] = m_buckets[bucket];
+            m_buckets[bucket] = index;
+        }
+        void insert_relocated(typeinfo_t value_type, usize hash, void* src)
+        {
+            increment_reserve(value_type, m_size + 1);
+            usize index = allocate_sparse_slot();
+            relocate_type(value_type, value_at(value_type, index), src);
+            link_slot(index, hash);
+            ++m_size;
+        }
+        void insert_copied(typeinfo_t value_type, usize hash, const void* src)
+        {
+            increment_reserve(value_type, m_size + 1);
+            usize index = allocate_sparse_slot();
+            copy_construct_type(value_type, value_at(value_type, index), src);
+            link_slot(index, hash);
+            ++m_size;
         }
         R<Variant> do_serialize(typeinfo_t value_type) const
         {
@@ -551,10 +642,9 @@ namespace Luna
             Variant ret(VariantType::array);
             lutry
             {
-                for (usize i = 0; i < m_buffer_size; ++i)
+                for (usize i = 0; i < m_sparse_size; ++i)
                 {
-                    usize h = m_cb_buffer[i].m_hash;
-                    if (h != RobinHoodHashing::EMPTY_SLOT && !RobinHoodHashing::is_tombstone(h))
+                    if (bit_test(m_occupied, i))
                     {
                         const void* v = (const void*)((usize)m_value_buffer + value_size * i);
                         lulet(var, serialize(value_type, v));
@@ -574,10 +664,17 @@ namespace Luna
     {
         HashTableData* d = (HashTableData*)inst;
         d->m_value_buffer = nullptr;
-        d->m_cb_buffer = nullptr;
-        d->m_buffer_size = 0;
+        d->m_hashes = nullptr;
+        d->m_nexts = nullptr;
+        d->m_occupied = nullptr;
+        d->m_buckets = nullptr;
+        d->m_capacity = 0;
+        d->m_sparse_size = 0;
         d->m_size = 0;
-        d->m_max_load_factor = RobinHoodHashing::INITIAL_LOAD_FACTOR;
+        d->m_first_free = SparseHashing::EMPTY_SLOT;
+        d->m_hole_count = 0;
+        d->m_bucket_count = 0;
+        d->m_max_load_factor = SparseHashing::INITIAL_LOAD_FACTOR;
     }
     static void hashmap_dtor(typeinfo_t type, void* inst)
     {
@@ -596,34 +693,27 @@ namespace Luna
     inline void hashtable_copy_ctor(typeinfo_t value_type, HashTableData* dest, HashTableData* src)
     {
         dest->m_value_buffer = nullptr;
-        dest->m_cb_buffer = nullptr;
-        dest->m_buffer_size = 0;
+        dest->m_hashes = nullptr;
+        dest->m_nexts = nullptr;
+        dest->m_occupied = nullptr;
+        dest->m_buckets = nullptr;
+        dest->m_capacity = 0;
+        dest->m_sparse_size = 0;
         dest->m_size = 0;
-        dest->m_max_load_factor = RobinHoodHashing::INITIAL_LOAD_FACTOR;
-        usize value_size = get_type_size(value_type);
+        dest->m_first_free = SparseHashing::EMPTY_SLOT;
+        dest->m_hole_count = 0;
+        dest->m_bucket_count = 0;
+        dest->m_max_load_factor = SparseHashing::INITIAL_LOAD_FACTOR;
         dest->m_max_load_factor = src->m_max_load_factor;
-        if (dest->load_factor() > dest->m_max_load_factor)
-        {
-            dest->rehash(value_type, 0);
-        }
         if (src->m_size)
         {
-            dest->m_value_buffer = memalloc(src->m_buffer_size * value_size, get_type_alignment(value_type));
-            dest->m_cb_buffer = (RobinHoodHashing::ControlBlock*)memalloc(src->m_buffer_size * sizeof(RobinHoodHashing::ControlBlock));
-            memzero(dest->m_cb_buffer, src->m_buffer_size * sizeof(RobinHoodHashing::ControlBlock));
-            dest->m_buffer_size = src->m_buffer_size;
-            for (usize i = 0; i < src->m_buffer_size; ++i)
+            for (usize i = 0; i < src->m_sparse_size; ++i)
             {
-                usize h = src->m_cb_buffer[i].m_hash;
-                dest->m_cb_buffer[i].m_hash = h;
-                if (h != RobinHoodHashing::EMPTY_SLOT && !RobinHoodHashing::is_tombstone(h))
+                if (bit_test(src->m_occupied, i))
                 {
-                    void* dest_buf = (void*)((usize)dest->m_value_buffer + i * value_size);
-                    void* src_buf = (void*)((usize)src->m_value_buffer + i * value_size);
-                    copy_construct_type(value_type, dest_buf, src_buf);
+                    dest->insert_copied(value_type, src->m_hashes[i], src->value_at(value_type, i));
                 }
             }
-            dest->m_size = src->m_size;
         }
     }
     static void hashmap_copy_ctor(typeinfo_t type, void* dest, const void* src)
@@ -643,8 +733,16 @@ namespace Luna
         HashTableData* srcd = (HashTableData*)src;
         memcpy(destd, srcd, sizeof(HashTableData));
         srcd->m_value_buffer = nullptr;
-        srcd->m_buffer_size = 0;
+        srcd->m_hashes = nullptr;
+        srcd->m_nexts = nullptr;
+        srcd->m_occupied = nullptr;
+        srcd->m_buckets = nullptr;
+        srcd->m_capacity = 0;
+        srcd->m_sparse_size = 0;
         srcd->m_size = 0;
+        srcd->m_first_free = SparseHashing::EMPTY_SLOT;
+        srcd->m_hole_count = 0;
+        srcd->m_bucket_count = 0;
     }
     static void hashmap_copy_assign(typeinfo_t type, void* dest, const void* src)
     {
@@ -673,11 +771,6 @@ namespace Luna
         typeinfo_t value_type = make_hashmap_value_type(generic_arguments[0].type, generic_arguments[1].type);
         return d->do_serialize(value_type);
     }
-    inline usize alter_hash(usize h)
-    {
-        if (h == RobinHoodHashing::EMPTY_SLOT) ++h;
-        return h & ~RobinHoodHashing::TOMBSTONE_BIT;
-    }
     static RV hashmap_deserialize(typeinfo_t type, void* inst, const Variant& data)
     {
         HashTableData* d = (HashTableData*)inst;
@@ -695,16 +788,14 @@ namespace Luna
             if(failed(r))
             {
                 destruct_type(value_type, value_buffer);
-                memfree(value_buffer);
+                memfree(value_buffer, value_alignment);
                 return r;
             }
             // Extract key type.
-            usize h = alter_hash(hash_type(key_type, value_buffer));
-            d->increment_reserve(value_type, d->m_size + 1);
-            robinhood_insert(h, value_type, value_size, value_alignment, value_buffer, d->m_value_buffer, d->m_cb_buffer, d->m_buffer_size);
-            ++d->m_size;
+            usize h = hash_type(key_type, value_buffer);
+            d->insert_relocated(value_type, h, value_buffer);
         }
-        memfree(value_buffer);
+        memfree(value_buffer, value_alignment);
         return ok;
     }
     static R<Variant> hashset_serialize(typeinfo_t type, const void* inst)
@@ -721,7 +812,6 @@ namespace Luna
         usize value_size = get_type_size(value_type);
         usize value_alignment = get_type_alignment(value_type);
         void* value_buffer = memalloc(value_size, value_alignment);
-        value_buffer = (void*)align_upper((usize)value_buffer, value_alignment);
         for (auto& v : data.values())
         {
             construct_type(value_type, value_buffer);
@@ -729,16 +819,14 @@ namespace Luna
             if(failed(r))
             {
                 destruct_type(value_type, value_buffer);
-                memfree(value_buffer);
+                memfree(value_buffer, value_alignment);
                 return r;
             }
             // Extract key type.
-            usize h = alter_hash(hash_type(value_type, value_buffer));
-            d->increment_reserve(value_type, d->m_size + 1);
-            robinhood_insert(h, value_type, value_size, value_alignment, value_buffer, d->m_value_buffer, d->m_cb_buffer, d->m_buffer_size);
-            ++d->m_size;
+            usize h = hash_type(value_type, value_buffer);
+            d->insert_relocated(value_type, h, value_buffer);
         }
-        memfree(value_buffer);
+        memfree(value_buffer, value_alignment);
         return ok;
     }
     static GenericStructureInstantiateInfo hashmap_instantiate(typeinfo_t base_type, Span<const GenericArgument> generic_arguments)

--- a/Tests/HashBenchmark/Source/main.cpp
+++ b/Tests/HashBenchmark/Source/main.cpp
@@ -1,0 +1,446 @@
+/*!
+* This file is a portion of LunaSDK.
+* For conditions of distribution and use, see the disclaimer
+* and license in LICENSE.txt
+*
+* @file main.cpp
+* @author JXMaster
+* @date 2026/6/3
+*/
+#include <Luna/Runtime/Runtime.hpp>
+#include <Luna/Runtime/HashMap.hpp>
+#include <Luna/Runtime/HashSet.hpp>
+#include <Luna/Runtime/RobinMap.hpp>
+#include <Luna/Runtime/RobinSet.hpp>
+#include <Luna/Runtime/UnorderedMap.hpp>
+#include <Luna/Runtime/UnorderedSet.hpp>
+#include <Luna/Runtime/Time.hpp>
+#include <Luna/Runtime/Vector.hpp>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+
+using namespace Luna;
+
+namespace
+{
+    volatile usize g_sink = 0;
+
+    struct Config
+    {
+        usize size = 117964;
+        usize lookup_ops = 471856;
+        usize churn_ops = 58982;
+        usize samples = 3;
+    };
+
+    struct Stats
+    {
+        usize size = 0;
+        usize capacity = 0;
+        usize buckets = 0;
+        f32 load_factor = 0.0f;
+    };
+
+    struct Trial
+    {
+        f64 ms = 0.0;
+        Stats stats;
+        usize sink = 0;
+    };
+
+    struct Result
+    {
+        const c8* scenario = nullptr;
+        const c8* container = nullptr;
+        const c8* operation = nullptr;
+        const c8* impl = nullptr;
+        f64 ms = 0.0;
+        f64 ns_per_op = 0.0;
+        Stats stats;
+        usize sink = 0;
+    };
+
+    u64 splitmix64(usize index)
+    {
+        u64 x = (u64)index + 0x9E3779B97F4A7C15ull;
+        x = (x ^ (x >> 30)) * 0xBF58476D1CE4E5B9ull;
+        x = (x ^ (x >> 27)) * 0x94D049BB133111EBull;
+        return x ^ (x >> 31);
+    }
+
+    usize parse_usize(const c8* text, usize fallback)
+    {
+        c8* end = nullptr;
+        usize value = (usize)strtoull(text, &end, 10);
+        return (end && *end == '\0' && value) ? value : fallback;
+    }
+
+    Config parse_config(int argc, char** argv)
+    {
+        Config cfg;
+        for (int i = 1; i + 1 < argc; ++i)
+        {
+            if (!strcmp(argv[i], "--size"))
+            {
+                cfg.size = parse_usize(argv[++i], cfg.size);
+            }
+            else if (!strcmp(argv[i], "--lookups"))
+            {
+                cfg.lookup_ops = parse_usize(argv[++i], cfg.lookup_ops);
+            }
+            else if (!strcmp(argv[i], "--churn"))
+            {
+                cfg.churn_ops = parse_usize(argv[++i], cfg.churn_ops);
+            }
+            else if (!strcmp(argv[i], "--samples"))
+            {
+                cfg.samples = parse_usize(argv[++i], cfg.samples);
+            }
+        }
+        return cfg;
+    }
+
+    template <typename _Container>
+    Stats get_stats(const _Container& c)
+    {
+        Stats ret;
+        ret.size = c.size();
+        ret.capacity = c.capacity();
+        ret.buckets = c.hash_table_size();
+        ret.load_factor = c.load_factor();
+        return ret;
+    }
+
+    template <typename _Kty, typename _Hash, typename _KeyEqual, typename _Alloc>
+    Stats get_stats(const UnorderedSet<_Kty, _Hash, _KeyEqual, _Alloc>& c)
+    {
+        Stats ret;
+        ret.size = c.size();
+        ret.capacity = c.capacity();
+        ret.buckets = c.bucket_count();
+        ret.load_factor = c.load_factor();
+        return ret;
+    }
+
+    template <typename _Kty, typename _Ty, typename _Hash, typename _KeyEqual, typename _Alloc>
+    Stats get_stats(const UnorderedMap<_Kty, _Ty, _Hash, _KeyEqual, _Alloc>& c)
+    {
+        Stats ret;
+        ret.size = c.size();
+        ret.capacity = c.capacity();
+        ret.buckets = c.bucket_count();
+        ret.load_factor = c.load_factor();
+        return ret;
+    }
+
+    f64 elapsed_ms(u64 start, u64 end)
+    {
+        return (f64)(end - start) * 1000.0 / get_ticks_per_second();
+    }
+
+    template <typename _Fn>
+    Result run_best(const c8* scenario, const c8* container, const c8* operation, const c8* impl, usize op_count, usize samples, _Fn&& fn)
+    {
+        Result best;
+        best.scenario = scenario;
+        best.container = container;
+        best.operation = operation;
+        best.impl = impl;
+        best.ms = 1.0e300;
+        for (usize i = 0; i < samples; ++i)
+        {
+            Trial t = fn();
+            g_sink ^= t.sink;
+            if (t.ms < best.ms)
+            {
+                best.ms = t.ms;
+                best.stats = t.stats;
+                best.sink = t.sink;
+            }
+        }
+        best.ns_per_op = best.ms * 1000000.0 / (f64)op_count;
+        return best;
+    }
+
+    void print_result(const Result& r)
+    {
+        printf("%-15s %-8s %-14s %-10s %10.3f %12.2f %10llu %10llu %10llu %8.2f\n",
+            r.scenario,
+            r.container,
+            r.operation,
+            r.impl,
+            r.ms,
+            r.ns_per_op,
+            (unsigned long long)r.stats.size,
+            (unsigned long long)r.stats.capacity,
+            (unsigned long long)r.stats.buckets,
+            (double)r.stats.load_factor);
+    }
+
+    template <typename _Set>
+    void build_set(_Set& set, const Vector<u64>& keys, f32 max_load_factor)
+    {
+        set.max_load_factor(max_load_factor);
+        set.reserve(keys.size());
+        for (usize i = 0; i < keys.size(); ++i)
+        {
+            set.insert(keys[i]);
+        }
+    }
+
+    template <typename _Map>
+    void build_map(_Map& map, const Vector<u64>& keys, f32 max_load_factor)
+    {
+        map.max_load_factor(max_load_factor);
+        map.reserve(keys.size());
+        for (usize i = 0; i < keys.size(); ++i)
+        {
+            map.insert(make_pair(keys[i], keys[i] ^ 0xD1B54A32D192ED03ull));
+        }
+    }
+
+    template <typename _Set>
+    Result bench_set_insert(const c8* scenario, const c8* impl, const Vector<u64>& keys, f32 max_load_factor, usize samples)
+    {
+        return run_best(scenario, "Set", "insert", impl, keys.size(), samples, [&]() {
+            _Set set;
+            set.max_load_factor(max_load_factor);
+            set.reserve(keys.size());
+            u64 start = get_ticks();
+            for (usize i = 0; i < keys.size(); ++i)
+            {
+                set.insert(keys[i]);
+            }
+            u64 end = get_ticks();
+            Trial ret;
+            ret.ms = elapsed_ms(start, end);
+            ret.stats = get_stats(set);
+            ret.sink = ret.stats.size ^ ret.stats.buckets;
+            return ret;
+        });
+    }
+
+    template <typename _Set>
+    Result bench_set_find_hit(const c8* scenario, const c8* impl, const Vector<u64>& keys, f32 max_load_factor, usize ops, usize samples)
+    {
+        return run_best(scenario, "Set", "find_hit", impl, ops, samples, [&]() {
+            _Set set;
+            build_set(set, keys, max_load_factor);
+            usize sink = 0;
+            u64 start = get_ticks();
+            for (usize i = 0; i < ops; ++i)
+            {
+                auto iter = set.find(keys[i % keys.size()]);
+                if (iter != set.end()) sink ^= (usize)*iter;
+            }
+            u64 end = get_ticks();
+            Trial ret;
+            ret.ms = elapsed_ms(start, end);
+            ret.stats = get_stats(set);
+            ret.sink = sink;
+            return ret;
+        });
+    }
+
+    template <typename _Set>
+    Result bench_set_find_miss(const c8* scenario, const c8* impl, const Vector<u64>& keys, const Vector<u64>& miss_keys, f32 max_load_factor, usize ops, usize samples)
+    {
+        return run_best(scenario, "Set", "find_miss", impl, ops, samples, [&]() {
+            _Set set;
+            build_set(set, keys, max_load_factor);
+            usize sink = 0;
+            u64 start = get_ticks();
+            for (usize i = 0; i < ops; ++i)
+            {
+                auto iter = set.find(miss_keys[i % miss_keys.size()]);
+                sink ^= (iter == set.end()) ? 1 : (usize)*iter;
+            }
+            u64 end = get_ticks();
+            Trial ret;
+            ret.ms = elapsed_ms(start, end);
+            ret.stats = get_stats(set);
+            ret.sink = sink;
+            return ret;
+        });
+    }
+
+    template <typename _Set>
+    Result bench_set_churn(const c8* scenario, const c8* impl, const Vector<u64>& keys, const Vector<u64>& churn_keys, f32 max_load_factor, usize ops, usize samples)
+    {
+        return run_best(scenario, "Set", "erase_insert", impl, ops * 2, samples, [&]() {
+            _Set set;
+            build_set(set, keys, max_load_factor);
+            usize sink = 0;
+            u64 start = get_ticks();
+            for (usize i = 0; i < ops; ++i)
+            {
+                sink ^= set.erase(keys[i % keys.size()]);
+                auto r = set.insert(churn_keys[i % churn_keys.size()]);
+                sink ^= r.second ? 3 : 7;
+            }
+            u64 end = get_ticks();
+            Trial ret;
+            ret.ms = elapsed_ms(start, end);
+            ret.stats = get_stats(set);
+            ret.sink = sink ^ set.size();
+            return ret;
+        });
+    }
+
+    template <typename _Map>
+    Result bench_map_insert(const c8* scenario, const c8* impl, const Vector<u64>& keys, f32 max_load_factor, usize samples)
+    {
+        return run_best(scenario, "Map", "insert", impl, keys.size(), samples, [&]() {
+            _Map map;
+            map.max_load_factor(max_load_factor);
+            map.reserve(keys.size());
+            u64 start = get_ticks();
+            for (usize i = 0; i < keys.size(); ++i)
+            {
+                map.insert(make_pair(keys[i], keys[i] ^ 0xD1B54A32D192ED03ull));
+            }
+            u64 end = get_ticks();
+            Trial ret;
+            ret.ms = elapsed_ms(start, end);
+            ret.stats = get_stats(map);
+            ret.sink = ret.stats.size ^ ret.stats.buckets;
+            return ret;
+        });
+    }
+
+    template <typename _Map>
+    Result bench_map_find_hit(const c8* scenario, const c8* impl, const Vector<u64>& keys, f32 max_load_factor, usize ops, usize samples)
+    {
+        return run_best(scenario, "Map", "find_hit", impl, ops, samples, [&]() {
+            _Map map;
+            build_map(map, keys, max_load_factor);
+            usize sink = 0;
+            u64 start = get_ticks();
+            for (usize i = 0; i < ops; ++i)
+            {
+                auto iter = map.find(keys[i % keys.size()]);
+                if (iter != map.end()) sink ^= (usize)iter->second;
+            }
+            u64 end = get_ticks();
+            Trial ret;
+            ret.ms = elapsed_ms(start, end);
+            ret.stats = get_stats(map);
+            ret.sink = sink;
+            return ret;
+        });
+    }
+
+    template <typename _Map>
+    Result bench_map_find_miss(const c8* scenario, const c8* impl, const Vector<u64>& keys, const Vector<u64>& miss_keys, f32 max_load_factor, usize ops, usize samples)
+    {
+        return run_best(scenario, "Map", "find_miss", impl, ops, samples, [&]() {
+            _Map map;
+            build_map(map, keys, max_load_factor);
+            usize sink = 0;
+            u64 start = get_ticks();
+            for (usize i = 0; i < ops; ++i)
+            {
+                auto iter = map.find(miss_keys[i % miss_keys.size()]);
+                sink ^= (iter == map.end()) ? 1 : (usize)iter->second;
+            }
+            u64 end = get_ticks();
+            Trial ret;
+            ret.ms = elapsed_ms(start, end);
+            ret.stats = get_stats(map);
+            ret.sink = sink;
+            return ret;
+        });
+    }
+
+    template <typename _Map>
+    Result bench_map_churn(const c8* scenario, const c8* impl, const Vector<u64>& keys, const Vector<u64>& churn_keys, f32 max_load_factor, usize ops, usize samples)
+    {
+        return run_best(scenario, "Map", "erase_insert", impl, ops * 2, samples, [&]() {
+            _Map map;
+            build_map(map, keys, max_load_factor);
+            usize sink = 0;
+            u64 start = get_ticks();
+            for (usize i = 0; i < ops; ++i)
+            {
+                sink ^= map.erase(keys[i % keys.size()]);
+                auto r = map.insert(make_pair(churn_keys[i % churn_keys.size()], churn_keys[i % churn_keys.size()] ^ 0xD1B54A32D192ED03ull));
+                sink ^= r.second ? 3 : 7;
+            }
+            u64 end = get_ticks();
+            Trial ret;
+            ret.ms = elapsed_ms(start, end);
+            ret.stats = get_stats(map);
+            ret.sink = sink ^ map.size();
+            return ret;
+        });
+    }
+
+    void fill_keys(Vector<u64>& keys, usize count, usize start_index)
+    {
+        keys.reserve(count);
+        for (usize i = 0; i < count; ++i)
+        {
+            keys.push_back(splitmix64(start_index + i));
+        }
+    }
+
+    void run_scenario(const c8* name, const Vector<u64>& keys, const Vector<u64>& miss_keys, const Vector<u64>& churn_keys, f32 sparse_load, f32 robin_load, f32 unordered_load, const Config& cfg)
+    {
+        print_result(bench_set_insert<HashSet<u64>>(name, "Hash", keys, sparse_load, cfg.samples));
+        print_result(bench_set_insert<RobinSet<u64>>(name, "Robin", keys, robin_load, cfg.samples));
+        print_result(bench_set_insert<UnorderedSet<u64>>(name, "Unord", keys, unordered_load, cfg.samples));
+        print_result(bench_set_find_hit<HashSet<u64>>(name, "Hash", keys, sparse_load, cfg.lookup_ops, cfg.samples));
+        print_result(bench_set_find_hit<RobinSet<u64>>(name, "Robin", keys, robin_load, cfg.lookup_ops, cfg.samples));
+        print_result(bench_set_find_hit<UnorderedSet<u64>>(name, "Unord", keys, unordered_load, cfg.lookup_ops, cfg.samples));
+        print_result(bench_set_find_miss<HashSet<u64>>(name, "Hash", keys, miss_keys, sparse_load, cfg.lookup_ops, cfg.samples));
+        print_result(bench_set_find_miss<RobinSet<u64>>(name, "Robin", keys, miss_keys, robin_load, cfg.lookup_ops, cfg.samples));
+        print_result(bench_set_find_miss<UnorderedSet<u64>>(name, "Unord", keys, miss_keys, unordered_load, cfg.lookup_ops, cfg.samples));
+        print_result(bench_set_churn<HashSet<u64>>(name, "Hash", keys, churn_keys, sparse_load, cfg.churn_ops, cfg.samples));
+        print_result(bench_set_churn<RobinSet<u64>>(name, "Robin", keys, churn_keys, robin_load, cfg.churn_ops, cfg.samples));
+        print_result(bench_set_churn<UnorderedSet<u64>>(name, "Unord", keys, churn_keys, unordered_load, cfg.churn_ops, cfg.samples));
+
+        print_result(bench_map_insert<HashMap<u64, u64>>(name, "Hash", keys, sparse_load, cfg.samples));
+        print_result(bench_map_insert<RobinMap<u64, u64>>(name, "Robin", keys, robin_load, cfg.samples));
+        print_result(bench_map_insert<UnorderedMap<u64, u64>>(name, "Unord", keys, unordered_load, cfg.samples));
+        print_result(bench_map_find_hit<HashMap<u64, u64>>(name, "Hash", keys, sparse_load, cfg.lookup_ops, cfg.samples));
+        print_result(bench_map_find_hit<RobinMap<u64, u64>>(name, "Robin", keys, robin_load, cfg.lookup_ops, cfg.samples));
+        print_result(bench_map_find_hit<UnorderedMap<u64, u64>>(name, "Unord", keys, unordered_load, cfg.lookup_ops, cfg.samples));
+        print_result(bench_map_find_miss<HashMap<u64, u64>>(name, "Hash", keys, miss_keys, sparse_load, cfg.lookup_ops, cfg.samples));
+        print_result(bench_map_find_miss<RobinMap<u64, u64>>(name, "Robin", keys, miss_keys, robin_load, cfg.lookup_ops, cfg.samples));
+        print_result(bench_map_find_miss<UnorderedMap<u64, u64>>(name, "Unord", keys, miss_keys, unordered_load, cfg.lookup_ops, cfg.samples));
+        print_result(bench_map_churn<HashMap<u64, u64>>(name, "Hash", keys, churn_keys, sparse_load, cfg.churn_ops, cfg.samples));
+        print_result(bench_map_churn<RobinMap<u64, u64>>(name, "Robin", keys, churn_keys, robin_load, cfg.churn_ops, cfg.samples));
+        print_result(bench_map_churn<UnorderedMap<u64, u64>>(name, "Unord", keys, churn_keys, unordered_load, cfg.churn_ops, cfg.samples));
+    }
+}
+
+int main(int argc, char** argv)
+{
+    init();
+    Config cfg = parse_config(argc, argv);
+    if (cfg.churn_ops > cfg.size) cfg.churn_ops = cfg.size;
+
+    Vector<u64> keys;
+    Vector<u64> miss_keys;
+    Vector<u64> churn_keys;
+    fill_keys(keys, cfg.size, 0);
+    fill_keys(miss_keys, cfg.size, cfg.size);
+    fill_keys(churn_keys, cfg.churn_ops, cfg.size * 2);
+
+    printf("HashBenchmark\n");
+    printf("size=%llu lookups=%llu churn=%llu samples=%llu\n",
+        (unsigned long long)cfg.size,
+        (unsigned long long)cfg.lookup_ops,
+        (unsigned long long)cfg.churn_ops,
+        (unsigned long long)cfg.samples);
+    printf("%-15s %-8s %-14s %-10s %10s %12s %10s %10s %10s %8s\n",
+        "scenario", "kind", "operation", "impl", "ms", "ns/op", "size", "capacity", "buckets", "load");
+
+    run_scenario("target-lf09", keys, miss_keys, churn_keys, 0.9f, 0.9f, 0.9f, cfg);
+    run_scenario("sparse-default", keys, miss_keys, churn_keys, 2.0f, 0.9f, 2.0f, cfg);
+
+    printf("sink=%llu\n", (unsigned long long)g_sink);
+    close();
+    return 0;
+}

--- a/Tests/HashBenchmark/xmake.lua
+++ b/Tests/HashBenchmark/xmake.lua
@@ -1,0 +1,6 @@
+target("HashBenchmark")
+    set_luna_sdk_test()
+    set_kind("binary")
+    add_files("Source/*.cpp")
+    add_deps("Runtime")
+target_end()

--- a/Tests/RuntimeTest/Source/HashTest.cpp
+++ b/Tests/RuntimeTest/Source/HashTest.cpp
@@ -742,6 +742,112 @@ namespace Luna
         }
 
         {
+            HashMap<int, int> h;
+            h.reserve(4);
+            h.insert(make_pair(1, 10));
+            h.insert(make_pair(2, 20));
+            h.insert(make_pair(3, 30));
+            h.insert(make_pair(4, 40));
+            h.erase(2);
+            h.shrink_to_fit();
+            lutest(h.find(1)->second == 10);
+            lutest(h.find(2) == h.end());
+            lutest(h.find(3)->second == 30);
+            lutest(h.find(4)->second == 40);
+        }
+
+        {
+            HashSet<int> h;
+            h.reserve(16);
+            h.insert(4);
+            h.insert(1);
+            h.insert(3);
+            h.insert(2);
+            h.erase(3);
+            h.insert(0);
+
+            h.sort();
+            int expected[] = { 0, 1, 2, 4 };
+            usize index = 0;
+            for (auto iter = h.begin(); iter != h.end(); ++iter)
+            {
+                lutest(*iter == expected[index]);
+                ++index;
+            }
+            lutest(index == 4);
+            for (usize i = 0; i < 4; ++i)
+            {
+                lutest(h.find(expected[i]) != h.end());
+            }
+
+            h.erase(1);
+            h.insert(5);
+            lutest(h.find(5) != h.end());
+            h.sort([](int lhs, int rhs) { return lhs > rhs; });
+            int expected_desc[] = { 5, 4, 2, 0 };
+            index = 0;
+            for (auto iter = h.begin(); iter != h.end(); ++iter)
+            {
+                lutest(*iter == expected_desc[index]);
+                ++index;
+            }
+            lutest(index == 4);
+        }
+
+        {
+            HashMap<int, int> h;
+            h.reserve(16);
+            h.insert(make_pair(5, 50));
+            h.insert(make_pair(1, 10));
+            h.insert(make_pair(3, 30));
+            h.insert(make_pair(2, 20));
+            h.erase(3);
+            h.insert(make_pair(4, 40));
+
+            h.key_sort();
+            int expected_keys[] = { 1, 2, 4, 5 };
+            usize index = 0;
+            for (auto iter = h.begin(); iter != h.end(); ++iter)
+            {
+                lutest(iter->first == expected_keys[index]);
+                lutest(iter->second == expected_keys[index] * 10);
+                ++index;
+            }
+            lutest(index == 4);
+            for (usize i = 0; i < 4; ++i)
+            {
+                auto iter = h.find(expected_keys[i]);
+                lutest(iter != h.end());
+                lutest(iter->second == expected_keys[i] * 10);
+            }
+
+            h.value_sort([](int lhs, int rhs) { return lhs > rhs; });
+            int expected_values[] = { 50, 40, 20, 10 };
+            index = 0;
+            for (auto iter = h.begin(); iter != h.end(); ++iter)
+            {
+                lutest(iter->second == expected_values[index]);
+                ++index;
+            }
+            lutest(index == 4);
+
+            h.sort([](const HashMap<int, int>::value_type& lhs, const HashMap<int, int>::value_type& rhs) {
+                return lhs.second < rhs.second;
+            });
+            int expected_values_asc[] = { 10, 20, 40, 50 };
+            index = 0;
+            for (auto iter = h.begin(); iter != h.end(); ++iter)
+            {
+                lutest(iter->second == expected_values_asc[index]);
+                ++index;
+            }
+            lutest(index == 4);
+
+            h.insert_or_assign(2, 200);
+            lutest(h.find(2)->second == 200);
+        }
+
+        {
             // clone()
             // swap()
             HashSet<int> h1;

--- a/Tests/RuntimeTest/Source/HashTest.cpp
+++ b/Tests/RuntimeTest/Source/HashTest.cpp
@@ -14,6 +14,8 @@
 #include <Luna/Runtime/UnorderedMultiSet.hpp>
 #include <Luna/Runtime/HashMap.hpp>
 #include <Luna/Runtime/HashSet.hpp>
+#include <Luna/Runtime/RobinMap.hpp>
+#include <Luna/Runtime/RobinSet.hpp>
 #include <Luna/Runtime/Random.hpp>
 
 namespace Luna
@@ -547,13 +549,15 @@ namespace Luna
             }
             lutest(h.size() == 100);
             h.shrink_to_fit();
-            lutest(h.hash_table_size() == 100);
+            usize retained_hash_table_size = h.hash_table_size();
+            lutest(retained_hash_table_size >= h.size());
+            lutest(h.capacity() == h.size());
 
             h.clear();
             lutest(h.empty());
             lutest(h.size() == 0);
             //! When the set gets cleared, it retains the buffer.
-            lutest(h.hash_table_size() == 100);
+            lutest(h.hash_table_size() == retained_hash_table_size);
             //! The bucket can be freed by calling shrink_to_fit.
             h.shrink_to_fit();
             lutest(h.hash_table_size() == 0);
@@ -704,7 +708,7 @@ namespace Luna
             lutest(max_lf == (1.0f));
             h.rehash(10000);
             size_t n = h.hash_table_size();
-            lutest(n == 10000);
+            lutest(n >= 10000);
             for (int i = 0; i < 10000; ++i)
             {
                 h.insert(i);    // This also tests for high loading.
@@ -717,6 +721,24 @@ namespace Luna
             }
             size_t n3 = h.hash_table_size();
             lutest(n3 == n);    // Verify no rehashing has occurred, because all second insertions are failed.
+        }
+
+        {
+            // Sparse-array hashing does not relocate other values when one value is erased.
+            HashMap<int, int> h;
+            h.reserve(8);
+            h.insert(make_pair(1, 10));
+            h.insert(make_pair(2, 20));
+            h.insert(make_pair(3, 30));
+            auto iter = h.find(1);
+            auto value_ptr = &(*iter);
+            h.erase(2);
+            h.insert(make_pair(4, 40));
+            iter = h.find(1);
+            lutest(&(*iter) == value_ptr);
+            lutest(iter->second == 10);
+            lutest(h.find(2) == h.end());
+            lutest(h.find(4)->second == 40);
         }
 
         {
@@ -777,7 +799,7 @@ namespace Luna
             // In such case, since old version of robinhood_insert never replaces tombstones when existing_dist == dist, 
             // the search algorithm cannot find one available slot to insert the second value. We change the algorithm so
             // that if the desired pos is a tombstone, the swapping still occurs.
-            HashMap<int, int, round_10_hash> h1;
+            RobinMap<int, int, round_10_hash> h1;
             h1.insert(make_pair(11, 1));
             for (int i = 0; i < 1000; ++i)
             {
@@ -790,7 +812,7 @@ namespace Luna
             // Bug 20220627: robinhood_insert returns wrong pos when the key is not inserted in order.
 
             Vector<u64> ids;
-            HashMap<u64, u64> h;
+            RobinMap<u64, u64> h;
             const usize num_ids = 500;
             for (u64 i = 0; i < num_ids; ++i)
             {
@@ -822,6 +844,17 @@ namespace Luna
                 auto iter = h.find(ids[i]);
                 lutest(iter->second == i);
             }
+        }
+
+        {
+            RobinSet<int> h;
+            h.insert(1);
+            h.insert(2);
+            h.insert(2);
+            lutest(h.size() == 2);
+            lutest(h.find(1) != h.end());
+            lutest(h.erase(1) == 1);
+            lutest(h.find(1) == h.end());
         }
     }
 }

--- a/Tests/xmake.lua
+++ b/Tests/xmake.lua
@@ -1,5 +1,6 @@
 if is_plat("windows", "macosx", "linux") then
     includes("RuntimeTest")
+    includes("HashBenchmark")
     includes("VariantUtilsTest")
     includes("WindowTest")
     includes("RHITests")


### PR DESCRIPTION
The old robinhood hashing is now renamed as RobinSet and RobinMap.